### PR TITLE
fix: support older tools with legacy entrypoint definitions

### DIFF
--- a/.changeset/perfect-mangos-grow.md
+++ b/.changeset/perfect-mangos-grow.md
@@ -1,0 +1,6 @@
+---
+"openapi-msw": patch
+---
+
+Add legacy entrypoint definitions (types, module) for tools and bundlers that
+do not understand package.json#exports fields.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "README.md",
     "LICENSE"
   ],
+  "sideEffects": false,
+  "types": "./dist/exports/main.d.ts",
+  "module": "./dist/exports/main.js",
   "exports": {
     ".": {
       "types": "./dist/exports/main.d.ts",


### PR DESCRIPTION
Adds supports for tools that do not understand `exports` fields in the package.json file.