### PR TITLE
chore: stop formatting the changelog

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,8 @@
-.changeset/*.md
 coverage
 dist
 node_modules
+
+# GitHub interprets "proseWrap" as a new line, which destroys the layout in
+# GitHub release notes, as they are created from the CHANGELOG.md entry.
+.changeset/*.md
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,9 @@
 
 ### Minor Changes
 
-- [#9](https://github.com/christoph-fricke/openapi-msw/pull/9)
-  [`6364870`](https://github.com/christoph-fricke/openapi-msw/commit/636487083c131f582507b096318d114c97131630)
-  Thanks [@christoph-fricke](https://github.com/christoph-fricke)! - Added
-  installation and complete usage guide to the documentation.
+- [#9](https://github.com/christoph-fricke/openapi-msw/pull/9) [`6364870`](https://github.com/christoph-fricke/openapi-msw/commit/636487083c131f582507b096318d114c97131630) Thanks [@christoph-fricke](https://github.com/christoph-fricke)! - Added installation and complete usage guide to the documentation.
 
-- [#5](https://github.com/christoph-fricke/openapi-msw/pull/5)
-  [`d15a0c2`](https://github.com/christoph-fricke/openapi-msw/commit/d15a0c2720f4d51415309f432cdc50aefb90f25f)
-  Thanks [@christoph-fricke](https://github.com/christoph-fricke)! - Added
-  `createOpenApiHttp(...)` to create a thin, type-safe wrapper around
-  [MSW](https://mswjs.io/)'s `http` that uses
-  [openapi-ts](https://openapi-ts.pages.dev/introduction/) `paths`:
-
+- [#5](https://github.com/christoph-fricke/openapi-msw/pull/5) [`d15a0c2`](https://github.com/christoph-fricke/openapi-msw/commit/d15a0c2720f4d51415309f432cdc50aefb90f25f) Thanks [@christoph-fricke](https://github.com/christoph-fricke)! - Added `createOpenApiHttp(...)` to create a thin, type-safe wrapper around [MSW](https://mswjs.io/)'s `http` that uses [openapi-ts](https://openapi-ts.pages.dev/introduction/) `paths`:
   ```ts
   import type { paths } from "./openapi-ts-definitions";
 


### PR DESCRIPTION
Formatting the changelog with "proseWrap: always" appears to cause bad line breaks in GitHub releases.