### PR TITLE
chore: reset changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,15 @@
 
 ### Patch Changes
 
-- [#12](https://github.com/christoph-fricke/openapi-msw/pull/12)
-  [`96ce15c`](https://github.com/christoph-fricke/openapi-msw/commit/96ce15c5f81535fb1091143dab2dce671ba65836)
-  Thanks [@christoph-fricke](https://github.com/christoph-fricke)! - Add legacy
-  entrypoint definitions (types, module) for tools and bundlers that do not
-  understand package.json#exports fields.
+- [#12](https://github.com/christoph-fricke/openapi-msw/pull/12) [`96ce15c`](https://github.com/christoph-fricke/openapi-msw/commit/96ce15c5f81535fb1091143dab2dce671ba65836) Thanks [@christoph-fricke](https://github.com/christoph-fricke)! - Add legacy entrypoint definitions (types, module) for tools and bundlers that do not understand package.json#exports fields.
 
 ## 0.1.0
 
 ### Minor Changes
 
-- [#9](https://github.com/christoph-fricke/openapi-msw/pull/9)
-  [`6364870`](https://github.com/christoph-fricke/openapi-msw/commit/636487083c131f582507b096318d114c97131630)
-  Thanks [@christoph-fricke](https://github.com/christoph-fricke)! - Added
-  installation and complete usage guide to the documentation.
+- [#9](https://github.com/christoph-fricke/openapi-msw/pull/9) [`6364870`](https://github.com/christoph-fricke/openapi-msw/commit/636487083c131f582507b096318d114c97131630) Thanks [@christoph-fricke](https://github.com/christoph-fricke)! - Added installation and complete usage guide to the documentation.
 
-- [#5](https://github.com/christoph-fricke/openapi-msw/pull/5)
-  [`d15a0c2`](https://github.com/christoph-fricke/openapi-msw/commit/d15a0c2720f4d51415309f432cdc50aefb90f25f)
-  Thanks [@christoph-fricke](https://github.com/christoph-fricke)! - Added
-  `createOpenApiHttp(...)` to create a thin, type-safe wrapper around
-  [MSW](https://mswjs.io/)'s `http` that uses
-  [openapi-ts](https://openapi-ts.pages.dev/introduction/) `paths`:
+- [#5](https://github.com/christoph-fricke/openapi-msw/pull/5) [`d15a0c2`](https://github.com/christoph-fricke/openapi-msw/commit/d15a0c2720f4d51415309f432cdc50aefb90f25f) Thanks [@christoph-fricke](https://github.com/christoph-fricke)! - Added `createOpenApiHttp(...)` to create a thin, type-safe wrapper around [MSW](https://mswjs.io/)'s `http` that uses [openapi-ts](https://openapi-ts.pages.dev/introduction/) `paths`:
 
   ```ts
   import type { paths } from "./openapi-ts-definitions";


### PR DESCRIPTION
The latest release was still based on a branch that formatted the changelog, thus reverting all the previous changes. This PR reverts it again.