### PR TITLE
fix: "empty response" handlers cannot return a response

### DIFF
--- a/.changeset/big-coats-tan.md
+++ b/.changeset/big-coats-tan.md
@@ -1,0 +1,15 @@
+---
+"openapi-msw": patch
+---
+
+Fixed OpenAPI operations with no-content responses cannot return a response. Now they are required to return an empty response, i.e. `null` as response body.
+
+```typescript
+const http = createOpenApiHttp<paths>();
+
+// Resolver function is required to return a `StrictResponse<null>` (empty response)
+// if the OpenAPI operation specifies `content?: never` for the response.
+const noContent = http.delete("/resource", ({ params }) => {
+  return HttpResponse.json(null, { status: 204 });
+});
+```

--- a/src/type-helpers.ts
+++ b/src/type-helpers.ts
@@ -60,12 +60,23 @@ export type ResponseBody<
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       responses: any;
     }
-    ? FilterKeys<
-        SuccessResponse<ResponseObjectMap<ApiSpec[Path][Method]>>,
-        MediaType
+    ? ConvertNoContent<
+        FilterKeys<
+          SuccessResponse<ResponseObjectMap<ApiSpec[Path][Method]>>,
+          MediaType
+        >
       >
     : never
   : never;
+
+/**
+ * OpenAPI-TS generates "no content" with `content?: never`.
+ * However, `new Response().body` is `null` and strictly typing no-content in MSW requires `null`.
+ * Therefore, this helper maps no-content to `null`.
+ */
+export type ConvertNoContent<Content> = [Content] extends [never]
+  ? null
+  : Content;
 
 /** MSW http handler factory with type inference for provided api paths. */
 export type HttpHandlerFactory<

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,9 @@
   "$schema": "https://json.schemastore.org/tsconfig.json",
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "declaration": true,
+    "sourceMap": true
   },
   "include": ["src", "exports"],
   "exclude": ["**/*.test.*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,10 +12,6 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
 
-    /* Emit */
-    "declaration": true,
-    "sourceMap": true,
-
     /* Type Checking */
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
This PR fixes #16 by remapping generated `never` responses to `null`. That has the nice effect that only strict responses that return `null` can be returned. Mapping to `undefined` would allow any response.
So if an endpoints changes from having a response content to no-content, it results in a conflict in the handler and is not silently accepted.