### PR TITLE
chore: fix prose-wrap in changelog files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,0 @@
-coverage
-dist
-node_modules
-
-# GitHub interprets "proseWrap" as a new line, which destroys the layout in
-# GitHub release notes, as they are created from the CHANGELOG.md entry.
-.changeset/*.md
-CHANGELOG.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/prettierrc.json",
-  "proseWrap": "always"
+  "proseWrap": "always",
+  "overrides": [
+    {
+      "files": [".changeset/*.md", "CHANGELOG.md"],
+      "options": {
+        "proseWrap": "never"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This PR reverts previous attempts to ignore "proseWrap" for changelog files, which still didn't work and still caused weirdly formatted GitHub releases. Instead, it applies the solution discovered by Paul Hachmang in this comment: https://github.com/changesets/changesets/issues/774#issuecomment-1064996654