### PR TITLE
fix: include sources in source map

### DIFF
--- a/.changeset/eighty-ads-remain.md
+++ b/.changeset/eighty-ads-remain.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": patch
+---
+
+fix compilation warning due to missing sources in source map

--- a/.changeset/eighty-ads-remain.md
+++ b/.changeset/eighty-ads-remain.md
@@ -2,4 +2,4 @@
 "openapi-msw": patch
 ---
 
-fix compilation warning due to missing sources in source map
+Fixed a compilation warning in projects using OpenAPI-MSW, which was caused by missing sources in source maps.

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "inlineSources": true
   },
   "include": ["src", "exports"],
   "exclude": ["**/*.test.*"]


### PR DESCRIPTION
fixes "Failed to parse source map from 'node_modules\openapi-msw\exports\main.ts'" error when serving with vite