### PR TITLE
fix(path): fragment types are not compatible with string runtime type

### DIFF
--- a/.changeset/tame-eyes-complain.md
+++ b/.changeset/tame-eyes-complain.md
@@ -1,0 +1,14 @@
+---
+"openapi-msw": patch
+---
+
+Fixed a type mismatch between path fragments and the values provided at runtime, which are always strings. Now all path-fragments are typed as string, except for string literals which are preserved. This fixes bug [#22](https://github.com/christoph-fricke/openapi-msw/issues/22).
+
+```typescript
+const handler = http.get("/resource/{count}", ({ params }) => {
+  // Previously calling "parseInt(...)" caused a type error when count was typed as number.
+  const count = parseInt(params.count);
+
+  return HttpResponse.json({ count });
+});
+```

--- a/.changeset/tame-eyes-complain.md
+++ b/.changeset/tame-eyes-complain.md
@@ -2,13 +2,14 @@
 "openapi-msw": patch
 ---
 
-Fixed a type mismatch between path fragments and the values provided at runtime, which are always strings. Now all path-fragments are typed as string, except for string literals which are preserved. This fixes bug [#22](https://github.com/christoph-fricke/openapi-msw/issues/22).
+Fixed a type mismatch between path fragment types and the values provided at runtime, which are always strings. Now all path-fragments are typed as string. If a fragment's schema is a string constrained by an enum, the resulting string literals are preserved. This fixes bug [#22](https://github.com/christoph-fricke/openapi-msw/issues/22).
 
 ```typescript
-const handler = http.get("/resource/{count}", ({ params }) => {
-  // Previously calling "parseInt(...)" caused a type error when count was typed as number.
-  const count = parseInt(params.count);
+const handler = http.get("/resource/{id}", ({ params }) => {
+  // Previously calling "parseInt(...)" caused a type error
+  // when the schema type for "id" is defined as number.
+  const id = parseInt(params.id);
 
-  return HttpResponse.json({ count });
+  return HttpResponse.json({ id });
 });
 ```

--- a/src/type-helpers.ts
+++ b/src/type-helpers.ts
@@ -37,9 +37,13 @@ export type PathParams<
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       parameters: { path: any };
     }
-    ? Required<ApiSpec[Path][Method]["parameters"]["path"]>
+    ? ConvertToStringLike<ApiSpec[Path][Method]["parameters"]["path"]>
     : never
   : never;
+
+type ConvertToStringLike<Params> = {
+  [Name in keyof Params]: Params[Name] extends string ? Params[Name] : string;
+};
 
 /** Extract the request body of a given path and method from an api spec. */
 export type RequestBody<

--- a/test/fixtures/path-fragments.api.yml
+++ b/test/fixtures/path-fragments.api.yml
@@ -44,6 +44,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Count"
+  /resource/{enum}:
+    parameters:
+      - name: enum
+        in: path
+        required: true
+        schema:
+          type: string
+          enum: [test1, test2]
+    get:
+      summary: Get Resource By Enum
+      operationId: getResourceEnum
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Resource"
   /resource:
     get:
       summary: Get Resource

--- a/test/no-content.test-d.ts
+++ b/test/no-content.test-d.ts
@@ -4,7 +4,7 @@ import { describe, expectTypeOf, test } from "vitest";
 import type { paths } from "./fixtures/no-content.api.js";
 
 describe("Given an OpenAPI schema endpoint with no-content", () => {
-  const http = createOpenApiHttp<paths>({ baseUrl: "*" });
+  const http = createOpenApiHttp<paths>();
 
   test("When an endpoint is mocked, Then responses with content cannot be returned", async () => {
     type Endpoint = typeof http.delete<"/resource">;

--- a/test/path-fragments.test-d.ts
+++ b/test/path-fragments.test-d.ts
@@ -21,9 +21,9 @@ describe("Given an OpenAPI schema endpoint that contains path fragments", () => 
     params.toEqualTypeOf<never>();
   });
 
-  test("When a path fragment is typed with non-string typed, Then the types are converted to strings", async () => {
+  test("When a path fragment is typed with non-string types, Then the type is converted to string", async () => {
     // The values passed in by MSW will always be strings at runtime.
-    // Therefore, we convert to to enable parsing, e.g. parseInt(...).
+    // Therefore, we convert to to enable runtime parsing, e.g. parseInt(...).
     type Endpoint = typeof http.get<"/resource/{count}">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const params = resolver.parameter(0).toHaveProperty("params");
@@ -31,7 +31,7 @@ describe("Given an OpenAPI schema endpoint that contains path fragments", () => 
     params.toEqualTypeOf<{ count: string }>();
   });
 
-  test("When a path fragment is typed with string literals, Then the literal values are preserved", async () => {
+  test("When a path fragment is typed with string literals, Then the literals are preserved", async () => {
     type Endpoint = typeof http.get<"/resource/{enum}">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const params = resolver.parameter(0).toHaveProperty("params");

--- a/test/path-fragments.test.ts
+++ b/test/path-fragments.test.ts
@@ -21,14 +21,13 @@ describe("Given an OpenAPI schema endpoint that contains path fragments", () => 
     expect(responseBody?.name).toBe("test-name");
   });
 
-  // FIXME: See https://github.com/christoph-fricke/openapi-msw/issues/22
-  test.skip("When a path fragments is defined as non-string, Then the fragment is still typed as a string", async () => {
+  test("When a path fragment is defined as a number, Then it can be parsed to a number", async () => {
     const request = new Request(
       new URL("/resource/42", "http://localhost:3000"),
     );
 
     const handler = http.get("/resource/{count}", ({ params }) => {
-      const count = params.count;
+      const count = parseInt(params.count);
 
       return HttpResponse.json({ count });
     });

--- a/test/path-fragments.test.ts
+++ b/test/path-fragments.test.ts
@@ -21,7 +21,7 @@ describe("Given an OpenAPI schema endpoint that contains path fragments", () => 
     expect(responseBody?.name).toBe("test-name");
   });
 
-  test("When a path fragment is defined as a number, Then it can be parsed to a number", async () => {
+  test("When a path fragment is specified as a number, Then it can be parsed to a number", async () => {
     const request = new Request(
       new URL("/resource/42", "http://localhost:3000"),
     );

--- a/test/request-body.test-d.ts
+++ b/test/request-body.test-d.ts
@@ -4,7 +4,7 @@ import { describe, expectTypeOf, test } from "vitest";
 import type { paths } from "./fixtures/request-body.api.js";
 
 describe("Given an OpenAPI schema endpoint with request content", () => {
-  const http = createOpenApiHttp<paths>({ baseUrl: "*" });
+  const http = createOpenApiHttp<paths>();
 
   test("When a request is expected to contain content, Then the content is strict-typed", () => {
     type Endpoint = typeof http.post<"/resource">;

--- a/test/response-content.test-d.ts
+++ b/test/response-content.test-d.ts
@@ -4,7 +4,7 @@ import { describe, expectTypeOf, test } from "vitest";
 import type { paths } from "./fixtures/response-content.api.js";
 
 describe("Given an OpenAPI schema endpoint with response content", () => {
-  const http = createOpenApiHttp<paths>({ baseUrl: "*" });
+  const http = createOpenApiHttp<paths>();
 
   test("When a JSON endpoint is mocked, Then responses must be a strict content response", async () => {
     type Endpoint = typeof http.get<"/resource">;


### PR DESCRIPTION
This PR changes the typing for the `params` to convert all path fragments to string. In case a fragment is a string literal type, the literal gets preserved. This fixes #22.