### PR TITLE
chore: sort imports during formatting

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/prettierrc.json",
+  "plugins": ["prettier-plugin-organize-imports"],
   "proseWrap": "always",
   "overrides": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "lint-staged": "^15.2.0",
         "openapi-typescript": "^7.0.0-next.5",
         "prettier": "^3.1.1",
+        "prettier-plugin-organize-imports": "^3.2.4",
         "rimraf": "^5.0.5",
         "typescript": "^5.3.3",
         "vitest": "^1.0.4"
@@ -5987,6 +5988,26 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.4.tgz",
+      "integrity": "sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==",
+      "dev": true,
+      "peerDependencies": {
+        "@volar/vue-language-plugin-pug": "^1.0.4",
+        "@volar/vue-typescript": "^1.0.4",
+        "prettier": ">=2.0",
+        "typescript": ">=2.9"
+      },
+      "peerDependenciesMeta": {
+        "@volar/vue-language-plugin-pug": {
+          "optional": true
+        },
+        "@volar/vue-typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lint-staged": "^15.2.0",
     "openapi-typescript": "^7.0.0-next.5",
     "prettier": "^3.1.1",
+    "prettier-plugin-organize-imports": "^3.2.4",
     "rimraf": "^5.0.5",
     "typescript": "^5.3.3",
     "vitest": "^1.0.4"

--- a/src/openapi-http.test.ts
+++ b/src/openapi-http.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, expect, it, vi } from "vitest";
 import { http as mswHttp } from "msw";
-import { createOpenApiHttp } from "./openapi-http.js";
+import { describe, expect, it, vi } from "vitest";
 import type { HttpMethod } from "./api-spec.js";
+import { createOpenApiHttp } from "./openapi-http.js";
 
 const methods: HttpMethod[] = [
   "get",

--- a/src/path-mapping.test.ts
+++ b/src/path-mapping.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "vitest";
 import { convertToColonPath } from "./path-mapping.js";
-import { describe, it, expect } from "vitest";
 
 describe(convertToColonPath, () => {
   it("should leave paths with no path fragments untouched", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
-import { name, exports } from "./package.json";
 import { defineProject } from "vitest/config";
+import { exports, name } from "./package.json";
 
 const suite = process.env["TEST_SUITE"];
 


### PR DESCRIPTION
This PR adds [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports) to sort imports in the same fashion as VS Code when code is formatted.