### PR TITLE
feat: add `response` helper to resolver info

### DIFF
--- a/.changeset/tasty-roses-walk.md
+++ b/.changeset/tasty-roses-walk.md
@@ -1,0 +1,52 @@
+---
+"openapi-msw": minor
+---
+
+Added `response` helper to the resolver-info argument. It provides an granular type-safety when creating HTTP responses. Instead of being able to return any status code, `response` limits status codes, content types, and their response bodies to the combinations defined by the given OpenAPI spec.
+
+```typescript
+/*
+Imagine this endpoint specification for the following example:
+
+/response-example:
+  get:
+    summary: Get Resource
+    operationId: getResource
+    responses:
+      200:
+        description: Success
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Resource"
+          text/plain:
+            schema:
+              type: string
+              enum: ["Hello", "Goodbye"]
+      204:
+        description: NoContent
+      "5XX":
+        description: Error
+        content:
+          text/plain:
+            schema:
+              type: string
+*/
+
+const handler = http.get("/response-example", ({ response }) => {
+  // Error: Status Code 204 only allows empty responses
+  const invalidRes = response(204).text("Hello");
+
+  // Error: Status Code 200 only allows "Hello" as text
+  const invalidRes = response(200).text("Some other string");
+
+  // No Error: This combination is part of the defined OpenAPI spec
+  const validRes = response(204).empty();
+
+  // No Error: This combination is part of the defined OpenAPI spec
+  const validRes = response(200).text("Hello");
+
+  // Using a wildcard requires you to provide a matching status code for the response
+  const validRes = response("5XX").text("Fatal Error", { status: 503 });
+});
+```

--- a/README.md
+++ b/README.md
@@ -146,9 +146,14 @@ const handler = http.get("/query-example", ({ query }) => {
 
 #### `response` Helper
 
-Type-safe response constructor that limits allowed response bodies based on the
-chosen status code and content type. For the following example, imagine an
-OpenAPI specification that defines various response options for an endpoint:
+Type-safe response constructor that narrows allowed response bodies based on the
+chosen status code and content type. This helper enables granular type-safety
+for responses. Instead of being able to return any status code, it limits status
+codes, content-types, and their response bodies to the combinations defined the
+given OpenAPI spec.
+
+For the following example, imagine an OpenAPI specification that defines various
+response options for an endpoint:
 
 | Status Code | Content-Type       | Content                |
 | :---------- | :----------------- | :--------------------- |

--- a/README.md
+++ b/README.md
@@ -37,11 +37,10 @@ type-safety and editor suggestion benefits:
   current path
 - **Request Body:** Automatically typed with the request-body schema of the
   current path
-- **Response:** Automatically forced to match the response-body schema of the
-  current path
+- **Response:** Automatically forced to match the available status-codes,
+  content-types, and response-bodies schema of the current path
 
 ```typescript
-import { HttpResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
 // 1. Import the paths from your OpenAPI schema definitions
 import type { paths } from "./your-openapi-schema";
@@ -50,23 +49,25 @@ import type { paths } from "./your-openapi-schema";
 const http = createOpenApiHttp<paths>();
 
 // TS only suggests available GET paths
-const getHandler = http.get("/resource/{id}", ({ params }) => {
+const getHandler = http.get("/resource/{id}", ({ params, response }) => {
   const id = params.id;
-  return HttpResponse.json({ id /* ... more response data */ });
+  return response(200).json({ id /* ... more response data */ });
 });
 
 // TS only suggests available POST paths
-const postHandler = http.post("/resource", async ({ request, query }) => {
-  // TS infers available query parameters from the OpenAPI schema
-  const sortDir = query.get("sort");
+const postHandler = http.post(
+  "/resource",
+  async ({ request, query, response }) => {
+    const sortDir = query.get("sort");
 
-  const data = await request.json();
-  return HttpResponse.json({ ...data /* ... more response data */ });
-});
+    const data = await request.json();
+    return response(201).json({ ...data /* ... more response data */ });
+  },
+);
 
 // TS shows an error when "/unknown" is not defined in the OpenAPI schema paths
 const otherHandler = http.get("/unknown", () => {
-  return new HttpResponse();
+  return new Response();
 });
 ```
 
@@ -110,7 +111,8 @@ one for unknown paths instead.
 
 For an even better type-safe experience, OpenAPI-MSW provides optional helpers
 that are attached to MSW's resolver-info argument. Currently, the helper `query`
-is provided for type-safe access to query parameters.
+is provided for type-safe access to query parameters. Furthermore, the helper
+`response` can be used for enhanced type-safety when creating HTTP responses.
 
 #### `query` Helper
 
@@ -139,6 +141,100 @@ const handler = http.get("/query-example", ({ query }) => {
   return HttpResponse.json({
     /* ... */
   });
+});
+```
+
+#### `response` Helper
+
+Type-safe response constructor that limits allowed response bodies based on the
+chosen status code and content type. For the following example, imagine an
+OpenAPI specification that defines various response options for an endpoint:
+
+| Status Code | Content-Type       | Content                |
+| :---------- | :----------------- | :--------------------- |
+| `200`       | `application/json` | _Some Object Schema_   |
+| `200`       | `text/plain`       | Literal: "Hello World" |
+| `204`       |                    | No Content             |
+
+```typescript
+const http = createOpenApiHttp<paths>();
+
+const handler = http.get("/response-example", ({ response }) => {
+  // Error: Status Code 204 only allows "no content"
+  const invalidRes = response(204).text("Hello World");
+
+  // Error: Status Code 200 does not allow "no content"
+  const invalidRes = response(200).empty();
+
+  // Error: Status Code 200 only allows "Hello World" as text
+  const invalidRes = response(200).text("Some other string");
+
+  // No Error: This combination is part of the defined OpenAPI spec
+  const validRes = response(204).empty();
+
+  // No Error: This combination is part of the defined OpenAPI spec
+  const validRes = response(200).text("Hello World");
+
+  // No Error: This combination is part of the defined OpenAPI spec
+  const validRes = response(200).json({
+    /* ... */
+  });
+});
+```
+
+##### Wildcard Status Codes
+
+The OpenAPI specification allows the
+[definition of wildcard status codes](https://spec.openapis.org/oas/v3.1.0#patterned-fields-0),
+such as `"default"`, `"3XX"`, and `"5XX"`. OpenAPI-MSW's `response` helper
+supports using wildcards as status codes. When a wildcard is used, TypeScript
+requires you to provide a matching status code that will be used for the
+response. Allowed status codes are inferred automatically and suggested based on
+[RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes).
+
+**Note:** The `"default"` wildcard is categorized as "any error status code" in
+OpenAPI-TS. To align with this assumption, OpenAPI-MSW only allows matching
+`"4XX"` and `"5XX"` status codes for the response when the `"default"` wildcard
+is used.
+
+```typescript
+const http = createOpenApiHttp<paths>();
+
+const handler = http.get("/untyped-response-example", ({ response }) => {
+  // Error: A wildcards is used but no status code provided
+  const invalidRes = response("5XX").text("Fatal Error");
+
+  // Error: Provided status code does not match the used wildcard
+  const invalidRes = response("5XX").text("Fatal Error", { status: 403 });
+
+  // Error: Provided status code is not defined in RFC 9110
+  const invalidRes = response("5XX").text("Fatal Error", { status: 520 });
+
+  // No Error: Provided status code matches the used wildcard
+  const validRes = response("5XX").text("Fatal Error", { status: 503 });
+
+  // No Error: "default" wildcard allows 5XX and 4XX status codes
+  const validRes = response("default").text("Fatal Error", { status: 507 });
+});
+```
+
+##### Untyped Response Fallback
+
+Sometimes an OpenAPI spec might not define all status codes that are returned.
+This can be quite common for server error responses (5XX). Nonetheless, still
+being able to test those with MSW is helpful. OpenAPI-MSW supports this scenario
+with an `untyped` wrapper on the `response` helper, which type-casts any
+response into an allowed response.
+
+```typescript
+const http = createOpenApiHttp<paths>();
+
+const handler = http.get("/untyped-response-example", ({ response }) => {
+  // Any response wrapped with `untyped` can be returned.
+  // Regardless of the expected response body.
+  return response.untyped(
+    HttpResponse.json({ message: "Teapot" }, { status: 418 }),
+  );
 });
 ```
 

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -3,6 +3,7 @@ import type {
   MediaType,
   OperationRequestBodyContent,
   PathsWithMethod,
+  ResponseContent,
   ResponseObjectMap,
   SuccessResponse,
 } from "openapi-typescript-helpers";
@@ -64,6 +65,23 @@ export type RequestBody<
   Method extends HttpMethod,
 > = Method extends keyof ApiSpec[Path]
   ? OperationRequestBodyContent<ApiSpec[Path][Method]>
+  : never;
+
+export type ResponseMap<
+  ApiSpec extends AnyApiSpec,
+  Path extends keyof ApiSpec,
+  Method extends HttpMethod,
+> = Method extends keyof ApiSpec[Path]
+  ? ApiSpec[Path][Method] extends {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      responses: any;
+    }
+    ? {
+        [Status in keyof ApiSpec[Path][Method]["responses"]]: ResponseContent<
+          ApiSpec[Path][Method]["responses"][Status]
+        >;
+      }
+    : never
   : never;
 
 /** Extract the response body of a given path and method from an api spec. */

--- a/src/http-status-wildcard.ts
+++ b/src/http-status-wildcard.ts
@@ -1,0 +1,46 @@
+/**
+ * Mapping of status wildcards allowed in the OpenAPI specification to defined
+ * HTTP status codes.
+ *
+ * @see Allowed Wildcards: https://spec.openapis.org/oas/v3.1.0#patterned-fields-0
+ * @see Default Code: https://spec.openapis.org/oas/v3.1.0#fixed-fields-13
+ * @see Specified Status Codes: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+ * */
+export interface Wildcard {
+  "1XX": 100 | 101 | 102 | 103;
+  "2XX": 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207 | 208 | 226;
+  "3XX": 300 | 301 | 302 | 303 | 304 | 307 | 308;
+  "5XX": 500 | 501 | 502 | 503 | 504 | 507 | 508 | 510 | 511;
+  "4XX":
+    | 400
+    | 401
+    | 402
+    | 403
+    | 404
+    | 405
+    | 406
+    | 407
+    | 408
+    | 409
+    | 410
+    | 411
+    | 412
+    | 413
+    | 414
+    | 415
+    | 416
+    | 417
+    | 418
+    | 421
+    | 422
+    | 423
+    | 424
+    | 425
+    | 426
+    | 428
+    | 429
+    | 431
+    | 451;
+  // Follows OpenAPI-TS in considering "default" as only being 4XX or 5XX.
+  default: Wildcard["4XX"] | Wildcard["5XX"];
+}

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -52,8 +52,8 @@ export interface ResponseResolverInfo<
    * });
    */
   response: OpenApiResponse<
-    ResponseBody<ApiSpec, Path, Method>,
-    ResponseMap<ApiSpec, Path, Method>
+    ResponseMap<ApiSpec, Path, Method>,
+    ResponseBody<ApiSpec, Path, Method>
   >;
 }
 

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -41,14 +41,33 @@ export interface ResponseResolverInfo<
    * });
    */
   query: QueryParamsUtil<QueryParams<ApiSpec, Path, Method>>;
+
   /**
-   * Helper function for creating responses based on status codes allowed in the
-   * provided OpenAPI spec.
+   * A type-safe response helper that narrows allowed status codes and content types,
+   * based on the given OpenAPI spec. The response body is further narrowed to
+   * the match the selected status code and content-type.
+   *
+   * If a wildcard status code is chosen, a returning status code must be provided
+   * in the response init. Status code allowed by the wildcard are inferred.
+   *
+   * A fallback for returning any response without casting regardless of the OpenAPI spec
+   * is provided through `response.untyped(...)`.
    *
    * @example
    * const handler = http.get("/response-example", ({ response }) => {
-   *   // Helper provided type safety for the status code as well as the json body
    *   return response(200).json({id: 123});
+   * });
+   *
+   * const empty = http.get("/response-example", ({ response }) => {
+   *   return response(204).empty();
+   * });
+   *
+   * const wildcard = http.get("/response-example", ({ response }) => {
+   *   return response("5XX").text("Unexpected Error", { status: 501 });
+   * });
+   *
+   * const fallback = http.get("/response-example", ({ response }) => {
+   *   return response.untyped(new Response("Hello"));
    * });
    */
   response: OpenApiResponse<

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -42,14 +42,18 @@ export interface ResponseResolverInfo<
    */
   query: QueryParamsUtil<QueryParams<ApiSpec, Path, Method>>;
   /**
-   * Helper function for creating responses based on status codes defined in the
+   * Helper function for creating responses based on status codes allowed in the
    * provided OpenAPI spec.
    *
-   * TODO: Add more sophisticated JSDoc with example.
+   * @example
+   * const handler = http.get("/response-example", ({ response }) => {
+   *   // Helper provided type safety for the status code as well as the json body
+   *   return response(200).json({id: 123});
+   * });
    */
   response: OpenApiResponse<
-    ResponseMap<ApiSpec, Path, Method>,
-    ResponseBody<ApiSpec, Path, Method>
+    ResponseBody<ApiSpec, Path, Method>,
+    ResponseMap<ApiSpec, Path, Method>
   >;
 }
 

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -43,19 +43,20 @@ export interface ResponseResolverInfo<
   query: QueryParamsUtil<QueryParams<ApiSpec, Path, Method>>;
 
   /**
-   * A type-safe response helper that narrows allowed status codes and content types,
+   * A type-safe response helper that narrows allowed status codes and content types
    * based on the given OpenAPI spec. The response body is further narrowed to
    * the match the selected status code and content-type.
    *
-   * If a wildcard status code is chosen, a returning status code must be provided
-   * in the response init. Status code allowed by the wildcard are inferred.
+   * If a wildcard status code is chosen, a specific status code for the response
+   * must be provided in the {@linkcode ResponseInit} argument. All status codes
+   * allowed by the wildcard are inferred.
    *
    * A fallback for returning any response without casting regardless of the OpenAPI spec
    * is provided through `response.untyped(...)`.
    *
    * @example
    * const handler = http.get("/response-example", ({ response }) => {
-   *   return response(200).json({id: 123});
+   *   return response(200).json({ id: 123 });
    * });
    *
    * const empty = http.get("/response-example", ({ response }) => {

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -6,8 +6,10 @@ import type {
   QueryParams,
   RequestBody,
   ResponseBody,
+  ResponseMap,
 } from "./api-spec.js";
 import { QueryParams as QueryParamsUtil } from "./query-params.js";
+import { createResponseHelper, type OpenApiResponse } from "./response.js";
 
 /** Response resolver that gets provided to HTTP handler factories. */
 export type ResponseResolver<
@@ -39,6 +41,16 @@ export interface ResponseResolverInfo<
    * });
    */
   query: QueryParamsUtil<QueryParams<ApiSpec, Path, Method>>;
+  /**
+   * Helper function for creating responses based on status codes defined in the
+   * provided OpenAPI spec.
+   *
+   * TODO: Add more sophisticated JSDoc with example.
+   */
+  response: OpenApiResponse<
+    ResponseMap<ApiSpec, Path, Method>,
+    ResponseBody<ApiSpec, Path, Method>
+  >;
 }
 
 /** Wraps MSW's resolver function to provide additional info to a given resolver. */
@@ -50,7 +62,11 @@ export function createResolverWrapper<
   resolver: ResponseResolver<ApiSpec, Path, Method>,
 ): MSWResponseResolver<ApiSpec, Path, Method> {
   return (info) => {
-    return resolver({ ...info, query: new QueryParamsUtil(info.request) });
+    return resolver({
+      ...info,
+      query: new QueryParamsUtil(info.request),
+      response: createResponseHelper(),
+    });
   };
 }
 

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -45,14 +45,14 @@ export interface ResponseResolverInfo<
   /**
    * A type-safe response helper that narrows allowed status codes and content types
    * based on the given OpenAPI spec. The response body is further narrowed to
-   * the match the selected status code and content-type.
+   * the match the selected status code and content type.
    *
    * If a wildcard status code is chosen, a specific status code for the response
    * must be provided in the {@linkcode ResponseInit} argument. All status codes
    * allowed by the wildcard are inferred.
    *
-   * A fallback for returning any response without casting regardless of the OpenAPI spec
-   * is provided through `response.untyped(...)`.
+   * A fallback for returning any response without casting is provided
+   * through `response.untyped(...)`.
    *
    * @example
    * const handler = http.get("/response-example", ({ response }) => {

--- a/src/response.ts
+++ b/src/response.ts
@@ -29,7 +29,7 @@ type TextResponse<ResponseBody, Status> = (
 ) => StrictResponse<typeof body>;
 
 /** Creates a type-safe json response, which may require an additional status code. */
-type JSONResponse<ResponseBody, Status> = (
+type JsonResponse<ResponseBody, Status> = (
   body: ResponseBody extends DefaultBodyType ? ResponseBody : never,
   init: DynamicResponseInit<Status>,
 ) => StrictResponse<typeof body>;
@@ -57,7 +57,7 @@ export interface OpenApiResponse<
 
     json: JSONLike<ResponseMap[Status]> extends never
       ? unknown
-      : JSONResponse<JSONLike<ResponseMap[Status]>, Status>;
+      : JsonResponse<JSONLike<ResponseMap[Status]>, Status>;
 
     empty: FilterKeys<ResponseMap[Status], "no-content"> extends never
       ? unknown
@@ -83,7 +83,7 @@ export function createResponseHelper<
       });
     };
 
-    const json: JSONResponse<
+    const json: JsonResponse<
       JSONLike<ResponseMap[typeof status]>,
       typeof status
     > = (body, init) => {

--- a/src/response.ts
+++ b/src/response.ts
@@ -8,9 +8,9 @@ import type { FilterKeys, JSONLike } from "openapi-typescript-helpers";
 import type { Wildcard } from "./http-status-wildcard.js";
 
 /**
- * Requires or removes the status code from response init depending on the chosen
- * OpenAPI status code. When the status is a wildcard, a specific status code
- * must be provided.
+ * Requires or removes the status code from {@linkcode HttpResponseInit} depending
+ * on the chosen OpenAPI status code. When the status is a wildcard, a specific
+ * status code must be provided.
  */
 type DynamicResponseInit<Status> = Status extends keyof Wildcard
   ? ResponseInitForWildcard<Status>
@@ -100,8 +100,9 @@ export function createResponseHelper<
     return { text, json, empty };
   };
 
-  response.untyped = (response) =>
-    response as StrictResponse<ExpectedResponseBody>;
+  response.untyped = (response) => {
+    return response as StrictResponse<ExpectedResponseBody>;
+  };
 
   return response;
 }

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,0 +1,55 @@
+import {
+  HttpResponse,
+  type DefaultBodyType,
+  type HttpResponseInit,
+  type StrictResponse,
+} from "msw";
+import type { FilterKeys } from "openapi-typescript-helpers";
+
+export interface OpenApiResponse<
+  ResponseMap extends Record<number, unknown>,
+  // TODO: Should a resolver continue to only allow successful responses or a union of typed responses?
+  // The later, might make this generic for type casting obsolete.
+  ExpectedResponse extends DefaultBodyType,
+> {
+  // TODO: Handle status codes that contain "XX", e.g. 2XX, 4XX... 2XX --> 200, 201, 204...
+  <Status extends keyof ResponseMap>(
+    status: Status,
+  ): {
+    // TODO: Do we need to support more HttpResponse helpers? Those are the only onces that return a `StrictResponse`.
+    // Currently, our strict typed resolver do not allow returning a `Response` anyway...
+    text(
+      body: FilterKeys<ResponseMap[Status], `plain/${string}`>,
+      init?: Omit<HttpResponseInit, "status">,
+    ): StrictResponse<ExpectedResponse>;
+    json(
+      body: FilterKeys<ResponseMap[Status], `${string}/json`>,
+      init?: Omit<HttpResponseInit, "status">,
+    ): StrictResponse<ExpectedResponse>;
+  };
+  // TODO: Allow "untyped" helper to return any response as a fallback for unknown codes, e.g. 401, 5XX
+  untyped: typeof HttpResponse;
+}
+
+export function createResponseHelper<
+  ResponseMap extends Record<number, unknown>,
+  SuccessResponse extends DefaultBodyType,
+>(): OpenApiResponse<ResponseMap, SuccessResponse> {
+  const response: OpenApiResponse<ResponseMap, SuccessResponse> = (status) => {
+    return {
+      text: (body, init) =>
+        HttpResponse.text(body as string, {
+          ...init,
+          status: status as number,
+        }) as StrictResponse<SuccessResponse>,
+      json: (body, init) =>
+        HttpResponse.json(body as SuccessResponse, {
+          ...init,
+          status: status as number,
+        }),
+    };
+  };
+  response.untyped = HttpResponse;
+
+  return response;
+}

--- a/src/response.ts
+++ b/src/response.ts
@@ -33,17 +33,17 @@ export interface OpenApiResponse<
 
 export function createResponseHelper<
   ResponseMap extends Record<number, unknown>,
-  SuccessResponse extends DefaultBodyType,
->(): OpenApiResponse<ResponseMap, SuccessResponse> {
-  const response: OpenApiResponse<ResponseMap, SuccessResponse> = (status) => {
+  ExpectedResponse extends DefaultBodyType,
+>(): OpenApiResponse<ResponseMap, ExpectedResponse> {
+  const response: OpenApiResponse<ResponseMap, ExpectedResponse> = (status) => {
     return {
       text: (body, init) =>
         HttpResponse.text(body as string, {
           ...init,
           status: status as number,
-        }) as StrictResponse<SuccessResponse>,
+        }) as StrictResponse<ExpectedResponse>,
       json: (body, init) =>
-        HttpResponse.json(body as SuccessResponse, {
+        HttpResponse.json(body as ExpectedResponse, {
           ...init,
           status: status as number,
         }),

--- a/src/response.ts
+++ b/src/response.ts
@@ -40,9 +40,9 @@ type EmptyResponse<Status> = (
 ) => StrictResponse<null>;
 
 /**
- * A type-safe response helper that narrows available status codes and content-types,
+ * A type-safe response helper that narrows available status codes and content types,
  * based on the given OpenAPI spec. The response body is specifically narrowed to
- * the specified status code and content-type.
+ * the specified status code and content type.
  */
 export interface OpenApiResponse<
   ResponseMap,

--- a/test/fixtures/response-content.api.yml
+++ b/test/fixtures/response-content.api.yml
@@ -27,6 +27,33 @@ paths:
             text/plain:
               schema:
                 type: string
+  /multi-resource:
+    get:
+      summary: Get Multi Resource
+      operationId: getMultiResource
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Resource"
+            plain/text:
+              schema:
+                type: string
+                enum: ["Hello", "Goodby"]
+        418:
+          description: Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: number
+                required: [error, code]
 components:
   schemas:
     Resource:

--- a/test/fixtures/response-content.api.yml
+++ b/test/fixtures/response-content.api.yml
@@ -20,6 +20,8 @@ paths:
               schema:
                 type: string
                 enum: ["Hello", "Goodbye"]
+        204:
+          description: NoContent
         418:
           description: Error
           content:

--- a/test/fixtures/response-content.api.yml
+++ b/test/fixtures/response-content.api.yml
@@ -16,10 +16,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Resource"
-            plain/text:
+            text/plain:
               schema:
                 type: string
-                enum: ["Hello", "Goodby"]
+                enum: ["Hello", "Goodbye"]
         418:
           description: Error
           content:
@@ -37,33 +37,6 @@ paths:
             text/plain:
               schema:
                 type: string
-  /multi-resource:
-    get:
-      summary: Get Multi Resource
-      operationId: getMultiResource
-      responses:
-        200:
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Resource"
-            plain/text:
-              schema:
-                type: string
-                enum: ["Hello", "Goodby"]
-        418:
-          description: Error
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                  code:
-                    type: number
-                required: [error, code]
 components:
   schemas:
     Resource:

--- a/test/fixtures/response-content.api.yml
+++ b/test/fixtures/response-content.api.yml
@@ -26,6 +26,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Exception"
+        "5XX":
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Exception"
+        "default":
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Exception"
   /text-resource:
     get:
       summary: Get Text Resource

--- a/test/response-content.test-d.ts
+++ b/test/response-content.test-d.ts
@@ -16,7 +16,25 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
       StrictResponse<
         | { id: string; name: string; value: number }
         | "Hello"
-        | "Goodby"
+        | "Goodbye"
+        | { error: string; code: number }
+      >
+    >();
+  });
+
+  test("When the response untyped fallback is used, Then any response is casted to the expected response body", async () => {
+    type Endpoint = typeof http.get<"/resource">;
+    const resolver = expectTypeOf<Endpoint>().parameter(1);
+    const response = resolver.parameter(0).toHaveProperty("response");
+    const untyped = response.toHaveProperty("untyped");
+
+    untyped.toBeFunction();
+    untyped.parameter(0).toEqualTypeOf<Response>();
+    untyped.returns.toEqualTypeOf<
+      StrictResponse<
+        | { id: string; name: string; value: number }
+        | "Hello"
+        | "Goodbye"
         | { error: string; code: number }
       >
     >();

--- a/test/response-content.test-d.ts
+++ b/test/response-content.test-d.ts
@@ -109,36 +109,19 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
   test("When the response helper is used, Then the matching strict-typed responses are returned", async () => {
     http.get("/resource", ({ response }) => {
       expectTypeOf(response(200).text).returns.toEqualTypeOf<
-        StrictResponse<
-          | { id: string; name: string; value: number }
-          | "Hello"
-          | "Goodbye"
-          | { error: string; code: number }
-          | null
-        >
+        StrictResponse<"Hello" | "Goodbye">
       >();
 
       expectTypeOf(response(200).json).returns.toEqualTypeOf<
-        StrictResponse<
-          | { id: string; name: string; value: number }
-          | "Hello"
-          | "Goodbye"
-          | { error: string; code: number }
-          | null
-        >
+        StrictResponse<{ id: string; name: string; value: number }>
       >();
+
       expectTypeOf(response(204).empty).returns.toEqualTypeOf<
         StrictResponse<null>
       >();
 
       expectTypeOf(response("default").json).returns.toEqualTypeOf<
-        StrictResponse<
-          | { id: string; name: string; value: number }
-          | "Hello"
-          | "Goodbye"
-          | { error: string; code: number }
-          | null
-        >
+        StrictResponse<{ error: string; code: number }>
       >();
     });
   });

--- a/test/response-content.test.ts
+++ b/test/response-content.test.ts
@@ -42,4 +42,28 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
     expect(responseBody).toBe("Hello World");
     expect(result?.response?.status).toBe(200);
   });
+
+  test("When an endpoint return multiple media types or error codes, Then responses for all of them can be returned", async () => {
+    // TODO: Temporary test for playing with the new response helper...
+
+    http.get("/multi-resource", ({ response }) => {
+      return response(200).text("Hello"); // TS is able to provide hints on literal string responses. Not possible before. :chefkiss:
+    });
+
+    http.get("/multi-resource", ({ response }) => {
+      return response(200).json({ id: "test-id", name: "Test", value: 16 });
+    });
+
+    http.get("/multi-resource", ({ response }) => {
+      return response(418).json({
+        error:
+          "Type error are nicely displayed in this line when something is wrong...",
+        code: 9000,
+      });
+    });
+
+    http.get("/multi-resource", ({ response }) => {
+      return response.untyped.text("Hello");
+    });
+  });
 });

--- a/test/response-content.test.ts
+++ b/test/response-content.test.ts
@@ -47,7 +47,8 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
     // TODO: Temporary test for playing with the new response helper...
 
     http.get("/multi-resource", ({ response }) => {
-      return response(200).text("Hello"); // TS is able to provide hints on literal string responses. Not possible before. :chefkiss:
+      // TS is able to provide hints on literal string responses. Not possible before. :chefkiss:
+      return response(200).text("Hello");
     });
 
     http.get("/multi-resource", ({ response }) => {
@@ -56,14 +57,16 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
 
     http.get("/multi-resource", ({ response }) => {
       return response(418).json({
-        error:
-          "Type error are nicely displayed in this line when something is wrong...",
+        error: "Strict typed exception occurred.",
         code: 9000,
       });
     });
 
     http.get("/multi-resource", ({ response }) => {
-      return response.untyped.text("Hello");
+      // TODO: Will be changed to not require casting...
+      return response.untyped.text("Unexpected Error" as "Hello", {
+        status: 500,
+      });
     });
   });
 });

--- a/test/response-content.test.ts
+++ b/test/response-content.test.ts
@@ -47,6 +47,13 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
     // TODO: Temporary test for playing with the new response helper...
 
     http.get("/resource", ({ response }) => {
+      return response(204).empty();
+
+      //@ts-expect-error Assigning empty when status returns content should be allowed
+      return response(200).empty();
+    });
+
+    http.get("/resource", ({ response }) => {
       return response(200).text("Hello");
     });
 

--- a/test/response-content.test.ts
+++ b/test/response-content.test.ts
@@ -64,6 +64,10 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
         code: 9000,
       });
     });
+
+    http.get("/resource", ({ response }) => {
+      return response("5XX").json({ code: 1, error: "" }, { status: 502 });
+    });
   });
 
   test("When an endpoint is mocked with the fallback helper, Then any response can be returned", async () => {

--- a/test/response-content.test.ts
+++ b/test/response-content.test.ts
@@ -28,9 +28,7 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
   test("When a TEXT endpoint is mocked, Then text response content can be returned", async () => {
     const request = new Request(
       new URL("/text-resource", "http://localhost:3000"),
-      {
-        method: "get",
-      },
+      { method: "get" },
     );
 
     const handler = http.get("/text-resource", () => {
@@ -43,38 +41,72 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
     expect(result?.response?.status).toBe(200);
   });
 
-  test("When an endpoint return multiple media types or error codes, Then responses for all of them can be returned", async () => {
-    // TODO: Temporary test for playing with the new response helper...
-
-    http.get("/resource", ({ response }) => {
-      return response(204).empty();
-
-      //@ts-expect-error Assigning empty when status returns content should be allowed
-      return response(200).empty();
+  test("When the response helper is used for fix status codes, Then a JSON response can be returned", async () => {
+    const request = new Request(new URL("/resource", "http://localhost:3000"), {
+      method: "get",
     });
 
-    http.get("/resource", ({ response }) => {
+    const handler = http.get("/resource", ({ response }) => {
+      return response(418).json({ code: 123, error: "Something wrong." });
+    });
+    const result = await handler.run({ request });
+
+    const responseBody = await result?.response?.json();
+    expect(responseBody).toStrictEqual({
+      code: 123,
+      error: "Something wrong.",
+    });
+    expect(result?.response?.status).toBe(418);
+  });
+
+  test("When the response helper is used for fix status codes, Then a TEXT response can be returned", async () => {
+    const request = new Request(new URL("/resource", "http://localhost:3000"), {
+      method: "get",
+    });
+
+    const handler = http.get("/resource", ({ response }) => {
       return response(200).text("Hello");
     });
+    const result = await handler.run({ request });
 
-    http.get("/resource", ({ response }) => {
-      return response(200).json({ id: "test-id", name: "Test", value: 16 });
+    const responseBody = await result?.response?.text();
+    expect(responseBody).toBe("Hello");
+    expect(result?.response?.status).toBe(200);
+  });
+
+  test("When the response helper is used for fix status codes, Then a EMPTY response can be returned", async () => {
+    const request = new Request(new URL("/resource", "http://localhost:3000"), {
+      method: "get",
     });
 
-    http.get("/text-resource", ({ response }) => {
-      return response(200).text("Some Text");
+    const handler = http.get("/resource", ({ response }) => {
+      return response(204).empty();
+    });
+    const result = await handler.run({ request });
+
+    expect(result?.response?.body).toBeNull();
+    expect(result?.response?.status).toBe(204);
+  });
+
+  test("When the response helper is used for wildcard status codes, Then a specific response status must be chosen", async () => {
+    const request = new Request(new URL("/resource", "http://localhost:3000"), {
+      method: "get",
     });
 
-    http.get("/resource", ({ response }) => {
-      return response(418).json({
-        error: "Strict typed exception occurred.",
-        code: 9000,
-      });
+    const handler = http.get("/resource", ({ response }) => {
+      return response("5XX").json(
+        { code: 123, error: "Something wrong." },
+        { status: 503 },
+      );
     });
+    const result = await handler.run({ request });
 
-    http.get("/resource", ({ response }) => {
-      return response("5XX").json({ code: 1, error: "" }, { status: 502 });
+    const responseBody = await result?.response?.json();
+    expect(responseBody).toStrictEqual({
+      code: 123,
+      error: "Something wrong.",
     });
+    expect(result?.response?.status).toBe(503);
   });
 
   test("When an endpoint is mocked with the fallback helper, Then any response can be returned", async () => {


### PR DESCRIPTION
Missing stuff / Open questions are marked with "TODO" in the source code.