### PR TITLE
feat: include all status code and media types in response body union

### DIFF
--- a/.changeset/sharp-rivers-rescue.md
+++ b/.changeset/sharp-rivers-rescue.md
@@ -1,0 +1,33 @@
+---
+"openapi-msw": minor
+---
+
+Changed response bodies to be a union of all response bodies for all status codes and media types. This makes it possible to return responses for specified error codes without requiring a type cast. Imagine the following endpoint. Its response body is now typed as `StrictResponse<{ id: string, value: number } | string | null>`.
+
+```yaml
+/resource:
+  get:
+    summary: Get Resource
+    operationId: getResource
+    responses:
+      200:
+        description: Success
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id, value]
+              properties:
+                id:
+                  type: string
+                value:
+                  type: integer
+      202:
+        description: Accepted
+        content:
+          text/plain:
+            schema:
+              type: string
+      418:
+        description: NoContent
+```

--- a/.changeset/sharp-rivers-rescue.md
+++ b/.changeset/sharp-rivers-rescue.md
@@ -2,7 +2,7 @@
 "openapi-msw": minor
 ---
 
-Changed response bodies to be a union of all response bodies for all status codes and media types. This makes it possible to return responses for specified error codes without requiring a type cast. Imagine the following endpoint. Its response body is now typed as `StrictResponse<{ id: string, value: number } | string | null>`.
+Changed response body types to be a union of all response bodies for all status codes and media types. This makes it possible to return responses for specified error codes without requiring a type cast. Imagine the following endpoint. Its response body is now typed as `StrictResponse<{ id: string, value: number } | string | null>`.
 
 ```yaml
 /resource:

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -67,7 +67,7 @@ export type RequestBody<
   : never;
 
 /**
- * Extract a response map of a given path and method from an api spec.
+ * Extract a response map for a given path and method from an api spec.
  * A response map has the shape of (status -> media-type -> body).
  */
 export type ResponseMap<

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -1,12 +1,14 @@
 import type {
-  FilterKeys,
-  MediaType,
   OperationRequestBodyContent,
   PathsWithMethod,
+  ResponseContent,
   ResponseObjectMap,
-  SuccessResponse,
 } from "openapi-typescript-helpers";
-import type { ConvertToStringified } from "./type-utils.js";
+import type {
+  ConvertToStringified,
+  MapToValues,
+  ResolvedObjectUnion,
+} from "./type-utils.js";
 
 /** Base type that any api spec should extend. */
 export type AnyApiSpec = NonNullable<unknown>;
@@ -77,9 +79,12 @@ export type ResponseBody<
       responses: any;
     }
     ? ConvertNoContent<
-        FilterKeys<
-          SuccessResponse<ResponseObjectMap<ApiSpec[Path][Method]>>,
-          MediaType
+        MapToValues<
+          ResolvedObjectUnion<
+            ResponseContent<
+              MapToValues<ResponseObjectMap<ApiSpec[Path][Method]>>
+            >
+          >
         >
       >
     : never

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -20,3 +20,24 @@ export type OptionalKeys<O extends object> = {
   // eslint-disable-next-line @typescript-eslint/ban-types
   [K in keyof O]-?: {} extends Pick<O, K> ? K : never;
 }[keyof O];
+
+/**
+ * Combines a union of objects into a single object.
+ * This is useful for types like `keyof ({ a: string } | { b: string })`,
+ * which is `never` without {@link ResolvedObjectUnion}.
+ *
+ * A use-case example of such situation is mapping different media-types that
+ * split across multiple status codes.
+ *
+ * @see https://www.steveruiz.me/posts/smooshed-object-union
+ */
+export type ResolvedObjectUnion<T> = {
+  [K in T extends infer P ? keyof P : never]: T extends infer P
+    ? K extends keyof P
+      ? P[K]
+      : never
+    : never;
+};
+
+/** Maps an object into a union of all its inner values. */
+export type MapToValues<Obj> = Obj[keyof Obj];

--- a/test/fixtures/no-content.api.yml
+++ b/test/fixtures/no-content.api.yml
@@ -18,3 +18,31 @@ paths:
       responses:
         204:
           description: No Content
+  /no-content-resource:
+    get:
+      summary: Get Resource With No Content
+      operationId: getResourceNoContent
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Resource"
+        204:
+          description: NoContent
+components:
+  schemas:
+    Resource:
+      type: object
+      required:
+        - id
+        - name
+        - value
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        value:
+          type: integer

--- a/test/fixtures/response-content.api.yml
+++ b/test/fixtures/response-content.api.yml
@@ -16,6 +16,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Resource"
+            plain/text:
+              schema:
+                type: string
+                enum: ["Hello", "Goodby"]
+        418:
+          description: Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: number
+                required: [error, code]
   /text-resource:
     get:
       summary: Get Text Resource

--- a/test/fixtures/response-content.api.yml
+++ b/test/fixtures/response-content.api.yml
@@ -25,13 +25,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                  code:
-                    type: number
-                required: [error, code]
+                $ref: "#/components/schemas/Exception"
   /text-resource:
     get:
       summary: Get Text Resource
@@ -58,3 +52,11 @@ components:
           type: string
         value:
           type: integer
+    Exception:
+      type: object
+      required: [error, code]
+      properties:
+        error:
+          type: string
+        code:
+          type: number

--- a/test/no-content.test-d.ts
+++ b/test/no-content.test-d.ts
@@ -22,4 +22,15 @@ describe("Given an OpenAPI schema endpoint with no-content", () => {
     response.not.toEqualTypeOf<Response>();
     response.toEqualTypeOf<StrictResponse<null>>();
   });
+
+  test("When a endpoint with NoContent response is mocked, Then the no-content option is included in the response union", async () => {
+    type Endpoint = typeof http.get<"/no-content-resource">;
+    const resolver = expectTypeOf<Endpoint>().parameter(1);
+    const response = resolver.returns.extract<Response>();
+
+    response.not.toEqualTypeOf<Response>();
+    response.toEqualTypeOf<
+      StrictResponse<{ id: string; name: string; value: number } | null>
+    >();
+  });
 });

--- a/test/no-content.test-d.ts
+++ b/test/no-content.test-d.ts
@@ -23,7 +23,7 @@ describe("Given an OpenAPI schema endpoint with no-content", () => {
     response.toEqualTypeOf<StrictResponse<null>>();
   });
 
-  test("When a endpoint with NoContent response is mocked, Then the no-content option is included in the response union", async () => {
+  test("When a endpoint with a NoContent response is mocked, Then the no-content option is included in the response union", async () => {
     type Endpoint = typeof http.get<"/no-content-resource">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const response = resolver.returns.extract<Response>();

--- a/test/response-content.test-d.ts
+++ b/test/response-content.test-d.ts
@@ -13,7 +13,12 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
 
     response.not.toEqualTypeOf<Response>();
     response.toEqualTypeOf<
-      StrictResponse<{ id: string; name: string; value: number }>
+      StrictResponse<
+        | { id: string; name: string; value: number }
+        | "Hello"
+        | "Goodby"
+        | { error: string; code: number }
+      >
     >();
   });
 });


### PR DESCRIPTION
This PR changes how response bodies are mapped. Previously, it should have chosen the first 2XX status code with the first media type, according to the JSDocs from `openapi-typescript-helpers`. However, the JSDocs comments are a lie as the types pick the union of all 2XX responses with all media types. This causes problems with specs where different media types are used across multiple status codes (see the following example). It results in a response typing of `StrictResponse<null>` instead of `StrictResponse<{ /* ... */} | string>`.

```yaml
/resource:
    get:
      summary: Get Resource
      operationId: getResource
      responses:
        200:
          description: Success
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/Resource"
        202:
          description: Accepted
          content:
            text/plain:
              schema:
                type: string
```

With this PR, the strict response is now properly typed with a union of all available response bodies, e.g. `StrictResponse<{ /* ... */} | string>`. Since we already have a union of all successful responses anyway, I decided to extend it to also include the response bodies of status codes, i.e. error responses as well. This has been suggested in #38.

**However, this change also has one downside.** Imagine an endpoint that returns an entity on success and a error object on error. Previously, while writing the response object in an handler, the editor would only suggest keys for the entity object. With this PR the editor will now suggest keys from both the entity and error object. Even when the return response body already contains keys that are only available in the entity, the editor will continue to suggest keys from the error object. Thankfully, at least the type check still works as expected and detects responses that do not fulfill the expected schema.

Until we ship #41, this makes it harder to easily type response bodies on the fly as you mentally have to filter irrelevant suggestions. 