### PR TITLE
fix: endpoints with no query params should not allow any query key

### DIFF
--- a/.changeset/smart-crabs-deliver.md
+++ b/.changeset/smart-crabs-deliver.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": patch
+---
+
+Fixed endpoints with no specified query params allow any query key in the `query` helper. Now, providing any query key causes a type error.

--- a/.changeset/smart-crabs-deliver.md
+++ b/.changeset/smart-crabs-deliver.md
@@ -2,4 +2,4 @@
 "openapi-msw": patch
 ---
 
-Fixed endpoints with no specified query params allow any query key in the `query` helper. Now, providing any query key causes a type error.
+Fixed endpoints with no specified query params allow any query key in the `query` helper methods. Now, providing any query key causes a type error.

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -52,10 +52,17 @@ export type QueryParams<
       parameters: { query?: any };
     }
     ? ConvertToStringified<
-        Required<ApiSpec[Path][Method]["parameters"]>["query"]
+        StrictQueryParams<
+          Required<ApiSpec[Path][Method]["parameters"]>["query"]
+        >
       >
     : never
   : never;
+
+/** Ensures that query params are not usable in case no query params are specified (never). */
+type StrictQueryParams<Params> = [Params] extends [never]
+  ? NonNullable<unknown>
+  : Params;
 
 /** Extract the request body of a given path and method from an api spec. */
 export type RequestBody<

--- a/test/fixtures/query-params.api.yml
+++ b/test/fixtures/query-params.api.yml
@@ -5,6 +5,17 @@ info:
 servers:
   - url: http://localhost:3000
 paths:
+  /no-query:
+    get:
+      summary: No Query Params
+      operationId: getNoQuery
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Resource"
   /single-query:
     get:
       summary: Single Query Params

--- a/test/query-params.test-d.ts
+++ b/test/query-params.test-d.ts
@@ -44,4 +44,12 @@ describe("Given an OpenAPI schema endpoint with query parameters fragments", () 
       expectTypeOf(multiSortBy).toEqualTypeOf<("asc" | "desc")[]>();
     });
   });
+
+  test("When a endpoint with no query params is mocked, Then no query keys can be passed to the query helper", () => {
+    http.get("/no-query", ({ query }) => {
+      expectTypeOf(query.get).parameter(0).toEqualTypeOf<never>();
+      expectTypeOf(query.getAll).parameter(0).toEqualTypeOf<never>();
+      expectTypeOf(query.has).parameter(0).toEqualTypeOf<never>();
+    });
+  });
 });


### PR DESCRIPTION
This fixes endpoints with no specified query params. Previously, the would accept any query key. However, it is more helpful if they accept no query key at all.

closes #43