### PR TITLE
feat: enhanced request object typing

### DIFF
--- a/.changeset/perfect-pans-pump.md
+++ b/.changeset/perfect-pans-pump.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": minor
+---
+
+Added enhanced typing for the `request` object. Now, `request.json()` and `request.text()` infer their return type from the given OpenAPI request-body content schema. Previously, only `request.json()` has been inferred without considering the content-type.

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -1,4 +1,5 @@
 import type {
+  OperationRequestBody,
   OperationRequestBodyContent,
   PathsWithMethod,
 } from "openapi-typescript-helpers";
@@ -63,6 +64,22 @@ export type QueryParams<
 type StrictQueryParams<Params> = [Params] extends [never]
   ? NonNullable<unknown>
   : Params;
+
+/**
+ * Extract a request map for a given path and method from an api spec.
+ * A request map has the shape of (media-type -> body).
+ */
+export type RequestMap<
+  ApiSpec extends AnyApiSpec,
+  Path extends keyof ApiSpec,
+  Method extends HttpMethod,
+> = Method extends keyof ApiSpec[Path]
+  ? undefined extends OperationRequestBody<ApiSpec[Path][Method]>
+    ? Partial<
+        NonNullable<OperationRequestBody<ApiSpec[Path][Method]>>["content"]
+      >
+    : OperationRequestBody<ApiSpec[Path][Method]>["content"]
+  : never;
 
 /** Extract the request body of a given path and method from an api spec. */
 export type RequestBody<

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,13 @@
+import type { FilterKeys, JSONLike } from "openapi-typescript-helpers";
+
+/** A type-safe request helper that enhances native body methods based on the given OpenAPI spec. */
+export interface OpenApiRequest<RequestMap> extends Request {
+  json(): JSONLike<RequestMap> extends never
+    ? never
+    : Promise<JSONLike<RequestMap>>;
+  text(): FilterKeys<RequestMap, `text/${string}`> extends never
+    ? never
+    : FilterKeys<RequestMap, `text/${string}`> extends string
+      ? Promise<FilterKeys<RequestMap, `text/${string}`>>
+      : never;
+}

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -5,10 +5,12 @@ import type {
   PathParams,
   QueryParams,
   RequestBody,
+  RequestMap,
   ResponseBody,
   ResponseMap,
 } from "./api-spec.js";
 import { QueryParams as QueryParamsUtil } from "./query-params.js";
+import type { OpenApiRequest } from "./request.js";
 import { createResponseHelper, type OpenApiResponse } from "./response.js";
 
 /** Response resolver that gets provided to HTTP handler factories. */
@@ -26,6 +28,9 @@ export interface ResponseResolverInfo<
   Path extends keyof ApiSpec,
   Method extends HttpMethod,
 > extends MSWResponseResolverInfo<ApiSpec, Path, Method> {
+  /** Standard request with enhanced typing for body methods based on the given OpenAPI spec. */
+  request: OpenApiRequest<RequestMap<ApiSpec, Path, Method>>;
+
   /**
    * Type-safe wrapper around {@link URLSearchParams} that implements methods for
    * reading query parameters.
@@ -88,6 +93,9 @@ export function createResolverWrapper<
   return (info) => {
     return resolver({
       ...info,
+      request: info.request as OpenApiRequest<
+        RequestMap<ApiSpec, Path, Method>
+      >,
       query: new QueryParamsUtil(info.request),
       response: createResponseHelper(),
     });

--- a/test/fixtures/request-body.api.yml
+++ b/test/fixtures/request-body.api.yml
@@ -48,6 +48,23 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Resource"
+  /multi-body:
+    post:
+      summary: "Create from Text"
+      operationId: postTextBody
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              enum: ["Hello", "Goodbye"]
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewResource"
+      responses:
+        204:
+          description: NoContent
 components:
   schemas:
     Resource:

--- a/test/fixtures/request-body.api.yml
+++ b/test/fixtures/request-body.api.yml
@@ -50,8 +50,8 @@ paths:
                 $ref: "#/components/schemas/Resource"
   /multi-body:
     post:
-      summary: "Create from Text"
-      operationId: postTextBody
+      summary: "Create from Text or JSON"
+      operationId: postMultiBody
       requestBody:
         required: true
         content:


### PR DESCRIPTION
Add a new typing for the `request` object, which infers the `.json()` and `.text()` typings from defined media types. Previously, a union of all media types where used for the return-type of `.json()`.

closes #40 