### PR TITLE
fix: proper type inference for extended json mime types

### DIFF
--- a/.changeset/kind-dancers-return.md
+++ b/.changeset/kind-dancers-return.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": patch
+---
+
+Fixed type inference for extended JSON mime types, such as `application/problem+json`. Previously, APIs like `response(...).json` would be typed as `never` for such mime types. Now, they will be properly typed.

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,5 @@
-import type { FilterKeys, JSONLike } from "openapi-typescript-helpers";
+import type { FilterKeys } from "openapi-typescript-helpers";
+import type { JSONLike } from "./type-utils.js";
 
 /** A type-safe request helper that enhances native body methods based on the given OpenAPI spec. */
 export interface OpenApiRequest<RequestMap> extends Request {

--- a/src/response.ts
+++ b/src/response.ts
@@ -4,8 +4,9 @@ import {
   type HttpResponseInit,
   type StrictResponse,
 } from "msw";
-import type { FilterKeys, JSONLike } from "openapi-typescript-helpers";
+import type { FilterKeys } from "openapi-typescript-helpers";
 import type { Wildcard } from "./http-status-wildcard.js";
+import type { JSONLike } from "./type-utils.js";
 
 /**
  * Requires or removes the status code from {@linkcode HttpResponseInit} depending

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -1,7 +1,7 @@
 import type { FilterKeys } from "openapi-typescript-helpers";
 
 /**
- * Return any media type containing "json". Similar to `openapi-typescript-helpers`
+ * Returns any JSON mime type. Similar to `openapi-typescript-helpers`
  * version but actually works with types like "application/problem+json".
  */
 export type JSONLike<T> = FilterKeys<T, `${string}/${string}json`>;

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -1,3 +1,11 @@
+import type { FilterKeys } from "openapi-typescript-helpers";
+
+/**
+ * Return any media type containing "json". Similar to `openapi-typescript-helpers`
+ * version but actually works with types like "application/problem+json".
+ */
+export type JSONLike<T> = FilterKeys<T, `${string}/${string}json`>;
+
 /**
  * Converts a type to string while preserving string literal types.
  * {@link Array}s are unboxed to their stringified value.

--- a/test/fixtures/request-body.api.yml
+++ b/test/fixtures/request-body.api.yml
@@ -67,8 +67,8 @@ paths:
           description: NoContent
   /special-json:
     post:
-      summary: Get Special JSON Response
-      operationId: getSpecialJSON
+      summary: Create for Special JSON
+      operationId: postSpecialJSON
       requestBody:
         required: true
         content:

--- a/test/fixtures/request-body.api.yml
+++ b/test/fixtures/request-body.api.yml
@@ -65,6 +65,19 @@ paths:
       responses:
         204:
           description: NoContent
+  /special-json:
+    post:
+      summary: Get Special JSON Response
+      operationId: getSpecialJSON
+      requestBody:
+        required: true
+        content:
+          application/ld+json:
+            schema:
+              $ref: "#/components/schemas/NewResource"
+      responses:
+        204:
+          description: NoContent
 components:
   schemas:
     Resource:

--- a/test/fixtures/response-content.api.yml
+++ b/test/fixtures/response-content.api.yml
@@ -51,6 +51,24 @@ paths:
             text/plain:
               schema:
                 type: string
+  /special-json:
+    get:
+      summary: Get Special JSON Response
+      operationId: getSpecialJSON
+      responses:
+        200:
+          description: Success
+          content:
+            application/ld+json:
+              schema:
+                $ref: "#/components/schemas/Resource"
+
+        401:
+          description: Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Exception"
 components:
   schemas:
     Resource:

--- a/test/request-body.test-d.ts
+++ b/test/request-body.test-d.ts
@@ -34,7 +34,7 @@ describe("Given an OpenAPI schema endpoint with request content", () => {
       .returns.resolves.toEqualTypeOf<{ name: string; value: number }>();
   });
 
-  test("When a requests uses a special JSON mime type, Then the content is strict-typed", async () => {
+  test("When a request uses a special JSON mime type, Then the content is strict-typed", async () => {
     type Endpoint = typeof http.post<"/special-json">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const request = resolver.parameter(0).toHaveProperty("request");

--- a/test/request-body.test-d.ts
+++ b/test/request-body.test-d.ts
@@ -34,6 +34,17 @@ describe("Given an OpenAPI schema endpoint with request content", () => {
       .returns.resolves.toEqualTypeOf<{ name: string; value: number }>();
   });
 
+  test("When a requests uses a special JSON mime type, Then the content is strict-typed", async () => {
+    type Endpoint = typeof http.post<"/special-json">;
+    const resolver = expectTypeOf<Endpoint>().parameter(1);
+    const request = resolver.parameter(0).toHaveProperty("request");
+
+    request.toHaveProperty("text").returns.toEqualTypeOf<never>();
+    request
+      .toHaveProperty("json")
+      .returns.resolves.toEqualTypeOf<{ name: string; value: number }>();
+  });
+
   test("When a request content is optional, Then the content is strict-typed with optional", () => {
     type Endpoint = typeof http.patch<"/resource">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);

--- a/test/response-content.test-d.ts
+++ b/test/response-content.test-d.ts
@@ -144,4 +144,16 @@ describe("Given an OpenAPI schema endpoint with response content", () => {
       >
     >();
   });
+
+  test("When special JSON mime types are used, Then the response json helper still works", async () => {
+    http.get("/special-json", ({ response }) => {
+      expectTypeOf(response(200).json).returns.toEqualTypeOf<
+        StrictResponse<{ id: string; name: string; value: number }>
+      >();
+
+      expectTypeOf(response(401).json).returns.toEqualTypeOf<
+        StrictResponse<{ error: string; code: number }>
+      >();
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes a problem with type inference for extended json mime types, such as `application/problem+json`. Previously OpenAPI-MSW would not catch such mime-types and would infer that an endpoint should not receive or return JSON. Thus `response(...).json` would be typed as `never`. Now, it will be typed with the proper JSON response.