### PR TITLE
refactor: remove openapi-typescript-helpers dependency

### DIFF
--- a/.changeset/eight-feet-heal.md
+++ b/.changeset/eight-feet-heal.md
@@ -2,4 +2,4 @@
 "openapi-msw": minor
 ---
 
-Removed dependency to `openapi-typescript-helpers`. We were depending on an older version without being able to easily update. With this refactoring, you projects should no longer resolve to multiple versions of `openapi-typescript-helpers`.
+Removed dependency on `openapi-typescript-helpers`. We were depending on an older version without being able to easily update. With this refactoring, your projects should no longer resolve to multiple versions of `openapi-typescript-helpers`.

--- a/.changeset/eight-feet-heal.md
+++ b/.changeset/eight-feet-heal.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": minor
+---
+
+Removed dependency to `openapi-typescript-helpers`. We were depending on an older version without being able to easily update. With this refactoring, you projects should no longer resolve to multiple versions of `openapi-typescript-helpers`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "openapi-msw",
       "version": "0.7.1",
       "license": "MIT",
-      "dependencies": {
-        "openapi-typescript-helpers": "0.0.8"
-      },
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.12",
@@ -4050,12 +4047,6 @@
       "peerDependencies": {
         "typescript": "^5.x"
       }
-    },
-    "node_modules/openapi-typescript-helpers": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.8.tgz",
-      "integrity": "sha512-1eNjQtbfNi5Z/kFhagDIaIRj6qqDzhjNJKz8cmMW0CVdGwT6e1GLbAfgI0d28VTJa1A8jz82jm/4dG8qNoNS8g==",
-      "license": "MIT"
     },
     "node_modules/openapi-typescript/node_modules/supports-color": {
       "version": "9.4.0",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
     "version": "changeset version && npm i",
     "release": "changeset publish"
   },
-  "dependencies": {
-    "openapi-typescript-helpers": "0.0.8"
-  },
   "peerDependencies": {
     "msw": "^2.0.0"
   },

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,14 +1,13 @@
-import type { FilterKeys } from "openapi-typescript-helpers";
-import type { JSONLike } from "./type-utils.js";
+import type { JSONLike, TextLike } from "./type-utils.js";
 
 /** A type-safe request helper that enhances native body methods based on the given OpenAPI spec. */
 export interface OpenApiRequest<RequestMap> extends Request {
   json(): JSONLike<RequestMap> extends never
     ? never
     : Promise<JSONLike<RequestMap>>;
-  text(): FilterKeys<RequestMap, `text/${string}`> extends never
+  text(): TextLike<RequestMap> extends never
     ? never
-    : FilterKeys<RequestMap, `text/${string}`> extends string
-      ? Promise<FilterKeys<RequestMap, `text/${string}`>>
+    : TextLike<RequestMap> extends string
+      ? Promise<TextLike<RequestMap>>
       : never;
 }

--- a/src/response.ts
+++ b/src/response.ts
@@ -4,9 +4,8 @@ import {
   type HttpResponseInit,
   type StrictResponse,
 } from "msw";
-import type { FilterKeys } from "openapi-typescript-helpers";
 import type { Wildcard } from "./http-status-wildcard.js";
-import type { JSONLike } from "./type-utils.js";
+import type { JSONLike, NoContent, TextLike } from "./type-utils.js";
 
 /**
  * Requires or removes the status code from {@linkcode HttpResponseInit} depending
@@ -52,15 +51,15 @@ export interface OpenApiResponse<
   <Status extends keyof ResponseMap>(
     status: Status,
   ): {
-    text: FilterKeys<ResponseMap[Status], `text/${string}`> extends never
+    text: TextLike<ResponseMap[Status]> extends never
       ? unknown
-      : TextResponse<FilterKeys<ResponseMap[Status], `text/${string}`>, Status>;
+      : TextResponse<TextLike<ResponseMap[Status]>, Status>;
 
     json: JSONLike<ResponseMap[Status]> extends never
       ? unknown
       : JsonResponse<JSONLike<ResponseMap[Status]>, Status>;
 
-    empty: FilterKeys<ResponseMap[Status], "no-content"> extends never
+    empty: NoContent<ResponseMap[Status]> extends never
       ? unknown
       : EmptyResponse<Status>;
   };
@@ -75,7 +74,7 @@ export function createResponseHelper<
     status,
   ) => {
     const text: TextResponse<
-      FilterKeys<ResponseMap[typeof status], `text/${string}`>,
+      TextLike<ResponseMap[typeof status]>,
       typeof status
     > = (body, init) => {
       return HttpResponse.text(body, {

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -1,10 +1,13 @@
-import type { FilterKeys } from "openapi-typescript-helpers";
+export type FilterKeys<Obj, Matchers> = Obj[keyof Obj & Matchers];
 
-/**
- * Returns any JSON mime type. Similar to `openapi-typescript-helpers`
- * version but actually works with types like "application/problem+json".
- */
+/** Returns any JSON mime type. Works with types like "application/problem+json". */
 export type JSONLike<T> = FilterKeys<T, `${string}/${string}json`>;
+
+/** Returns any TEXT mime type. */
+export type TextLike<T> = FilterKeys<T, `text/${string}`>;
+
+/** Returns any special "no-content" entry. Special no-content entries are added by `ConvertContent`. */
+export type NoContent<T> = FilterKeys<T, "no-content">;
 
 /**
  * Converts a type to string while preserving string literal types.


### PR DESCRIPTION
We were relying on an oder version of this dependency without being able to easily update. by removing it, we were able to simplify the `RequestMap` type, which previously relied on it.