### PR TITLE
feat!: update msw peer dependency to latest version

### DIFF
--- a/.changeset/eight-feet-heal.md
+++ b/.changeset/eight-feet-heal.md
@@ -2,4 +2,4 @@
 "openapi-msw": minor
 ---
 
-Removed dependency on `openapi-typescript-helpers`. We were depending on an older version without being able to easily update. With this refactoring, your projects should no longer resolve to multiple versions of `openapi-typescript-helpers`.
+Removed dependency on _openapi-typescript-helpers_. We were depending on an older version without being able to easily update. With this refactoring, your projects should no longer resolve to multiple versions of _openapi-typescript-helpers_.

--- a/.changeset/nasty-peaches-applaud.md
+++ b/.changeset/nasty-peaches-applaud.md
@@ -2,4 +2,4 @@
 "openapi-msw": major
 ---
 
-Updated MSW peer dependency from v2.0.0 to v2.7.0. This is only a breaking change if you are not already using the latest version of MSW.
+Updated MSW peer dependency from _v2.0.0_ to _v2.7.0_. This is only a breaking change if you are not already using the latest version of MSW.

--- a/.changeset/nasty-peaches-applaud.md
+++ b/.changeset/nasty-peaches-applaud.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": major
+---
+
+Updated MSW peer dependency from v2.0.0 to v2.7.0. This is only a breaking change if you are not already using the latest version of MSW.

--- a/.changeset/twenty-tables-allow.md
+++ b/.changeset/twenty-tables-allow.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": major
+---
+
+Renamed `HttpHandlerFactory` type to `OpenApiHttpRequestHandler`. This rename aligns its name with MSW's equivalent `HttpRequestHandler` type.

--- a/exports/main.ts
+++ b/exports/main.ts
@@ -2,9 +2,9 @@ export type { AnyApiSpec, HttpMethod } from "../src/api-spec.js";
 
 export {
   createOpenApiHttp,
-  type HttpHandlerFactory,
   type HttpOptions,
   type OpenApiHttpHandlers,
+  type OpenApiHttpRequestHandler,
 } from "../src/openapi-http.js";
 
 export type {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "vitest": "^3.0.4"
       },
       "peerDependencies": {
-        "msw": "^2.0.0"
+        "msw": "^2.7.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "release": "changeset publish"
   },
   "peerDependencies": {
-    "msw": "^2.0.0"
+    "msw": "^2.7.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -1,4 +1,7 @@
-import type { AsyncResponseResolverReturnType, http } from "msw";
+import type {
+  AsyncResponseResolverReturnType,
+  HttpResponseResolver,
+} from "msw";
 import type {
   AnyApiSpec,
   HttpMethod,
@@ -114,10 +117,8 @@ export type MSWResponseResolver<
   ApiSpec extends AnyApiSpec,
   Path extends keyof ApiSpec,
   Method extends HttpMethod,
-> = Parameters<
-  typeof http.all<
-    PathParams<ApiSpec, Path, Method>,
-    RequestBody<ApiSpec, Path, Method>,
-    ResponseBody<ApiSpec, Path, Method>
-  >
->[1];
+> = HttpResponseResolver<
+  PathParams<ApiSpec, Path, Method>,
+  RequestBody<ApiSpec, Path, Method>,
+  ResponseBody<ApiSpec, Path, Method>
+>;


### PR DESCRIPTION
This updates the peer dependency on MSW to its latest version. With this change we can benefit from some newly exposed types.

It is a small breaking change and thus causes a major release.