### PR TITLE
feat(request): add override for cloned request to remain type-safe

### DIFF
--- a/.changeset/angry-feet-dance.md
+++ b/.changeset/angry-feet-dance.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": minor
+---
+
+Added a `request.clone()` type override to continue returning type-safe `OpenApiRequest`s when called. With this, cloning the `request` in resolvers does not lose its type-safety on body parsing methods.

--- a/src/request.ts
+++ b/src/request.ts
@@ -2,6 +2,7 @@ import type { JSONLike, TextLike } from "./type-utils.js";
 
 /** A type-safe request helper that enhances native body methods based on the given OpenAPI spec. */
 export interface OpenApiRequest<RequestMap> extends Request {
+  clone(): OpenApiRequest<RequestMap>;
   json(): JSONLike<RequestMap> extends never
     ? never
     : Promise<JSONLike<RequestMap>>;

--- a/test/request-body.test-d.ts
+++ b/test/request-body.test-d.ts
@@ -69,4 +69,18 @@ describe("Given an OpenAPI schema endpoint with request content", () => {
       .toHaveProperty("json")
       .returns.resolves.toEqualTypeOf<{ name: string; value: number }>();
   });
+
+  test("When the request is cloned, Then it remains strict-typed", () => {
+    type Endpoint = typeof http.post<"/multi-body">;
+    const resolver = expectTypeOf<Endpoint>().parameter(1);
+    const request = resolver.parameter(0).toHaveProperty("request");
+    const cloned = request.toHaveProperty("clone").returns;
+
+    cloned
+      .toHaveProperty("text")
+      .returns.resolves.toEqualTypeOf<"Hello" | "Goodbye">();
+    cloned
+      .toHaveProperty("json")
+      .returns.resolves.toEqualTypeOf<{ name: string; value: number }>();
+  });
 });


### PR DESCRIPTION
This PR adds a small adjustment to the `OpenApiRequest` type to return the type-safe request typing when `Request.prototype.clone` is called. With this cloned requests remain strict typed and do not loose their type safety.