### PR TITLE
feat: add http utility types

### DIFF
--- a/.changeset/fifty-groups-judge.md
+++ b/.changeset/fifty-groups-judge.md
@@ -1,0 +1,25 @@
+---
+"openapi-msw": minor
+---
+
+Added utility types for creating type-safe functionality around OpenAPI-MSW. Special thanks to [@DrewHoo](https://github.com/DrewHoo) for suggesting and inspiring this change.
+
+```typescript
+import {
+  createOpenApiHttp,
+  type PathsFor,
+  type RequestBodyFor,
+  type ResponseBodyFor,
+} from "openapi-msw";
+
+const http = createOpenApiHttp<paths>();
+
+// A union of all possible GET paths.
+type Paths = PathsFor<typeof http.get>;
+
+// The request body for POST /tasks.
+type RequestBody = RequestBodyFor<typeof http.post, "/tasks">;
+
+// The response body for GET /tasks.
+type ResponseBody = ResponseBodyFor<typeof http.get, "/tasks">;
+```

--- a/README.md
+++ b/README.md
@@ -254,6 +254,32 @@ const handler = http.get("/untyped-response-example", ({ response }) => {
 });
 ```
 
+### Advanced: Utility Types
+
+OpenAPI-MSW exports utility types that can help you with creating type-safe
+functionality around OpenAPI-MSW. These utility types are centered around the
+request handlers exposed through the `http` object.
+
+```typescript
+import {
+  createOpenApiHttp,
+  type PathsFor,
+  type RequestBodyFor,
+  type ResponseBodyFor,
+} from "openapi-msw";
+
+const http = createOpenApiHttp<paths>();
+
+// A union of all possible GET paths.
+type Paths = PathsFor<typeof http.get>;
+
+// The request body for POST /tasks.
+type RequestBody = RequestBodyFor<typeof http.post, "/tasks">;
+
+// The response body for GET /tasks.
+type ResponseBody = ResponseBodyFor<typeof http.get, "/tasks">;
+```
+
 ## License
 
 This package is published under the [MIT license](./LICENSE).

--- a/exports/main.ts
+++ b/exports/main.ts
@@ -11,3 +11,10 @@ export type {
   ResponseResolver,
   ResponseResolverInfo,
 } from "../src/response-resolver.js";
+
+export type {
+  AnyOpenApiHttpRequestHandler,
+  PathsFor,
+  RequestBodyFor,
+  ResponseBodyFor,
+} from "../src/openapi-http-utilities.js";

--- a/src/openapi-http-utilities.ts
+++ b/src/openapi-http-utilities.ts
@@ -1,0 +1,62 @@
+import type {
+  AnyApiSpec,
+  HttpMethod,
+  PathsForMethod,
+  RequestBody,
+  ResponseBody,
+} from "./api-spec.js";
+import type { OpenApiHttpRequestHandler } from "./openapi-http.js";
+
+/**
+ * Base type that generic {@link OpenApiHttpRequestHandler | OpenApiHttpRequestHandlers}
+ * can extend.
+ */
+export type AnyOpenApiHttpRequestHandler = OpenApiHttpRequestHandler<
+  AnyApiSpec,
+  HttpMethod
+>;
+
+/**
+ * Extracts a union of all paths that can be provided to the given request handler.
+ *
+ * @example
+ * const http = createOpenApiHttp<paths>();
+ *
+ * type Paths = PathsFor<typeof http.get>;
+ */
+export type PathsFor<Handler extends AnyOpenApiHttpRequestHandler> =
+  Handler extends OpenApiHttpRequestHandler<infer ApiSpec, infer Method>
+    ? PathsForMethod<ApiSpec, Method>
+    : never;
+
+/**
+ * Extracts the request body of a specific path for the given request handler.
+ *
+ * @example
+ * const http = createOpenApiHttp<paths>();
+ *
+ * type RequestBody = RequestBodyFor<typeof http.post, "/create">;
+ */
+export type RequestBodyFor<
+  Handler extends AnyOpenApiHttpRequestHandler,
+  Path extends PathsFor<Handler>,
+> =
+  Handler extends OpenApiHttpRequestHandler<infer ApiSpec, infer Method>
+    ? RequestBody<ApiSpec, Path, Method>
+    : never;
+
+/**
+ * Extracts the response body of a specific path for the given request handler.
+ *
+ * @example
+ * const http = createOpenApiHttp<paths>();
+ *
+ * type ResponseBody = ResponseBodyFor<typeof http.get, "/tasks">;
+ */
+export type ResponseBodyFor<
+  Handler extends AnyOpenApiHttpRequestHandler,
+  Path extends PathsFor<Handler>,
+> =
+  Handler extends OpenApiHttpRequestHandler<infer ApiSpec, infer Method>
+    ? ResponseBody<ApiSpec, Path, Method>
+    : never;

--- a/test/fixtures/.redocly.yml
+++ b/test/fixtures/.redocly.yml
@@ -3,6 +3,10 @@ apis:
     root: ./http-methods.api.yml
     x-openapi-ts:
       output: ./http-methods.api.ts
+  http-utilities:
+    root: ./http-utilities.api.yml
+    x-openapi-ts:
+      output: ./http-utilities.api.ts
   no-content:
     root: ./no-content.api.yml
     x-openapi-ts:

--- a/test/fixtures/http-utilities.api.yml
+++ b/test/fixtures/http-utilities.api.yml
@@ -1,0 +1,66 @@
+openapi: 3.0.2
+info:
+  title: Http Utilities API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3000
+paths:
+  /resource/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get Resource By Id
+      operationId: getResourceById
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Resource"
+  /resource:
+    post:
+      summary: Create Resource
+      operationId: createResource
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewResource"
+      responses:
+        201:
+          description: Created
+    get:
+      summary: Get Resource
+      operationId: getResource
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Resource"
+components:
+  schemas:
+    Resource:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    NewResource:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string

--- a/test/http-utilities.test-d.ts
+++ b/test/http-utilities.test-d.ts
@@ -1,0 +1,38 @@
+import {
+  createOpenApiHttp,
+  type PathsFor,
+  type RequestBodyFor,
+  type ResponseBodyFor,
+} from "openapi-msw";
+import { describe, expectTypeOf, test } from "vitest";
+import type { paths } from "./fixtures/http-utilities.api.js";
+
+describe("Given an OpenApiHttpHandlers namespace", () => {
+  const http = createOpenApiHttp<paths>();
+
+  test("When paths are extracted, Then a path union is returned", () => {
+    const result = expectTypeOf<PathsFor<typeof http.get>>();
+
+    result.toEqualTypeOf<"/resource" | "/resource/{id}">();
+  });
+
+  test("When the request body is extracted, Then the request body is returned", () => {
+    const result =
+      expectTypeOf<RequestBodyFor<typeof http.post, "/resource">>();
+    const resultNoBody =
+      expectTypeOf<RequestBodyFor<typeof http.get, "/resource/{id}">>();
+
+    result.toEqualTypeOf<{ name: string }>();
+    resultNoBody.toEqualTypeOf<never>();
+  });
+
+  test("When the response body is extracted, Then the response body is returned", () => {
+    const result =
+      expectTypeOf<ResponseBodyFor<typeof http.get, "/resource">>();
+    const resultNoBody =
+      expectTypeOf<ResponseBodyFor<typeof http.post, "/resource">>();
+
+    result.toEqualTypeOf<{ id: string; name: string }>();
+    resultNoBody.toEqualTypeOf<null>();
+  });
+});


### PR DESCRIPTION
This PR adds and exposes utility types for extracting information from requests handlers. Exposed types are:

- `PathsFor`
- `RequestBodyFor`
- `ResponseBodyFor`

closes #75