### PR TITLE
feat: rendered code examples for resolver helpers

### DIFF
--- a/.changeset/puny-places-fall.md
+++ b/.changeset/puny-places-fall.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": minor
+---
+
+Updated TSDoc comments for `response` and `query` to show their code examples. Previously, VS Code did not display their `@example` blocks.

--- a/src/openapi-http-utilities.ts
+++ b/src/openapi-http-utilities.ts
@@ -19,10 +19,12 @@ export type AnyOpenApiHttpRequestHandler = OpenApiHttpRequestHandler<
 /**
  * Extracts a union of all paths that can be provided to the given request handler.
  *
- * @example
+ * **Example**
+ * ```typescript
  * const http = createOpenApiHttp<paths>();
  *
  * type Paths = PathsFor<typeof http.get>;
+ * ```
  */
 export type PathsFor<Handler extends AnyOpenApiHttpRequestHandler> =
   Handler extends OpenApiHttpRequestHandler<infer ApiSpec, infer Method>
@@ -32,10 +34,12 @@ export type PathsFor<Handler extends AnyOpenApiHttpRequestHandler> =
 /**
  * Extracts the request body of a specific path for the given request handler.
  *
- * @example
+ * **Example**
+ * ```typescript
  * const http = createOpenApiHttp<paths>();
  *
  * type RequestBody = RequestBodyFor<typeof http.post, "/create">;
+ * ```
  */
 export type RequestBodyFor<
   Handler extends AnyOpenApiHttpRequestHandler,
@@ -48,10 +52,12 @@ export type RequestBodyFor<
 /**
  * Extracts the response body of a specific path for the given request handler.
  *
- * @example
+ * **Example**
+ * ```typescript
  * const http = createOpenApiHttp<paths>();
  *
  * type ResponseBody = ResponseBodyFor<typeof http.get, "/tasks">;
+ * ```
  */
 export type ResponseBodyFor<
   Handler extends AnyOpenApiHttpRequestHandler,

--- a/src/openapi-http.ts
+++ b/src/openapi-http.ts
@@ -42,12 +42,11 @@ export interface HttpOptions {
 }
 
 /**
- * Creates a wrapper around MSW's {@link http} object, which is enhanced with
+ * Creates a wrapper around MSW's {@linkcode http} object, which is enhanced with
  * type inference from the provided OpenAPI-TS `paths` definition.
  *
- * @param options Additional options that are used by all defined HTTP handlers.
- *
- * @example
+ * **Usage**
+ * ```typescript
  * import { HttpResponse } from "msw";
  * import { createOpenApiHttp } from "openapi-msw";
  * // 1. Import the paths from your OpenAPI schema definitions
@@ -57,10 +56,13 @@ export interface HttpOptions {
  * const http = createOpenApiHttp<paths>();
  *
  * // TS only suggests available GET paths
- * const getHandler = http.get("/resource/{id}", ({ params }) => {
+ * const handler = http.get("/resource/{id}", ({ params }) => {
  *   const id = params.id;
  *   return HttpResponse.json({ id, other: "..." });
  * });
+ * ```
+ *
+ * @param options Additional options that are used by all defined HTTP handlers.
  */
 export function createOpenApiHttp<ApiSpec extends AnyApiSpec>(
   options?: HttpOptions,

--- a/src/path-mapping.ts
+++ b/src/path-mapping.ts
@@ -2,7 +2,7 @@
  * Converts a OpenAPI path fragment convention to the colon convention that is
  * commonly used in Node.js and also MSW.
  *
- * @example /users/{id} --> /users/:id
+ * **Example:** `/users/{id} --> /users/:id`
  */
 export function convertToColonPath(path: string, baseUrl?: string): string {
   const resolvedPath = path.replaceAll("{", ":").replaceAll("}", "");

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -38,7 +38,8 @@ export interface ResponseResolverInfo<
    * Type-safe wrapper around {@link URLSearchParams} that implements methods for
    * reading query parameters.
    *
-   * @example
+   * **Example**
+   * ```typescript
    * const handler = http.get("/query-example", ({ query }) => {
    *   const filter = query.get("filter");
    *   const sortBy = query.getAll("sortBy");
@@ -47,6 +48,7 @@ export interface ResponseResolverInfo<
    *
    *   return HttpResponse.json({ ... });
    * });
+   * ```
    */
   query: QueryParamsUtil<QueryParams<ApiSpec, Path, Method>>;
 
@@ -62,7 +64,8 @@ export interface ResponseResolverInfo<
    * A fallback for returning any response without casting is provided
    * through `response.untyped(...)`.
    *
-   * @example
+   * **Example**
+   * ```typescript
    * const handler = http.get("/response-example", ({ response }) => {
    *   return response(200).json({ id: 123 });
    * });
@@ -78,6 +81,7 @@ export interface ResponseResolverInfo<
    * const fallback = http.get("/response-example", ({ response }) => {
    *   return response.untyped(new Response("Hello"));
    * });
+   * ```
    */
   response: OpenApiResponse<
     ResponseMap<ApiSpec, Path, Method>,


### PR DESCRIPTION
Updated the TSDOC comments to display code examples in VS Code for response helpers.