### PR TITLE
feat: output declaration maps for proper jump-to-source support

### DIFF
--- a/.changeset/poor-trams-take.md
+++ b/.changeset/poor-trams-take.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": minor
+---
+
+Added declaration maps to the build output. Together with packaged source files, this enables proper "Go To Definition" support in editors — jumping directly to the TypeScript source file instead of the declaration file.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "repository": "github:christoph-fricke/openapi-msw",
   "files": [
     "dist",
+    "exports",
+    "src",
+    "!src/**/*.test.ts",
     "CHANGELOG.md",
     "README.md",
     "LICENSE"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,8 +4,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "declaration": true,
-    "sourceMap": true,
-    "inlineSources": true
+    "declarationMap": true,
+    "sourceMap": true
   },
   "include": ["src", "exports"],
   "exclude": ["**/*.test.*"]


### PR DESCRIPTION
This enables proper "Go To Definition" support in editors—jumping directly to the TypeScript source file instead of the declaration file.