### PR TITLE
refactor: use .ts extension for relative file imports

### DIFF
--- a/exports/main.ts
+++ b/exports/main.ts
@@ -1,20 +1,20 @@
-export type { AnyApiSpec, HttpMethod } from "../src/api-spec.js";
+export type { AnyApiSpec, HttpMethod } from "../src/api-spec.ts";
 
 export {
   createOpenApiHttp,
   type HttpOptions,
   type OpenApiHttpHandlers,
   type OpenApiHttpRequestHandler,
-} from "../src/openapi-http.js";
+} from "../src/openapi-http.ts";
 
 export type {
   ResponseResolver,
   ResponseResolverInfo,
-} from "../src/response-resolver.js";
+} from "../src/response-resolver.ts";
 
 export type {
   AnyOpenApiHttpRequestHandler,
   PathsFor,
   RequestBodyFor,
   ResponseBodyFor,
-} from "../src/openapi-http-utilities.js";
+} from "../src/openapi-http-utilities.ts";

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -2,7 +2,7 @@ import type {
   ConvertToStringified,
   MapToValues,
   ResolvedObjectUnion,
-} from "./type-utils.js";
+} from "./type-utils.ts";
 
 /** Base type that any api spec should extend. */
 export type AnyApiSpec = NonNullable<unknown>;

--- a/src/openapi-http-utilities.ts
+++ b/src/openapi-http-utilities.ts
@@ -4,8 +4,8 @@ import type {
   PathsForMethod,
   RequestBody,
   ResponseBody,
-} from "./api-spec.js";
-import type { OpenApiHttpRequestHandler } from "./openapi-http.js";
+} from "./api-spec.ts";
+import type { OpenApiHttpRequestHandler } from "./openapi-http.ts";
 
 /**
  * Base type that generic {@link OpenApiHttpRequestHandler | OpenApiHttpRequestHandlers}

--- a/src/openapi-http.test.ts
+++ b/src/openapi-http.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { http as mswHttp } from "msw";
 import { describe, expect, it, vi } from "vitest";
-import type { HttpMethod } from "./api-spec.js";
-import { createOpenApiHttp } from "./openapi-http.js";
+import type { HttpMethod } from "./api-spec.ts";
+import { createOpenApiHttp } from "./openapi-http.ts";
 
 const methods: HttpMethod[] = [
   "get",

--- a/src/openapi-http.ts
+++ b/src/openapi-http.ts
@@ -1,10 +1,10 @@
 import { http, type HttpHandler, type RequestHandlerOptions } from "msw";
-import type { AnyApiSpec, HttpMethod, PathsForMethod } from "./api-spec.js";
-import { convertToColonPath } from "./path-mapping.js";
+import type { AnyApiSpec, HttpMethod, PathsForMethod } from "./api-spec.ts";
+import { convertToColonPath } from "./path-mapping.ts";
 import {
   createResolverWrapper,
   type ResponseResolver,
-} from "./response-resolver.js";
+} from "./response-resolver.ts";
 
 /** HTTP handler factory with type inference for provided api paths. */
 export type OpenApiHttpRequestHandler<

--- a/src/path-mapping.test.ts
+++ b/src/path-mapping.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { convertToColonPath } from "./path-mapping.js";
+import { convertToColonPath } from "./path-mapping.ts";
 
 describe(convertToColonPath, () => {
   it("should leave paths with no path fragments untouched", () => {

--- a/src/query-params.ts
+++ b/src/query-params.ts
@@ -1,4 +1,4 @@
-import type { OptionalKeys } from "./type-utils.js";
+import type { OptionalKeys } from "./type-utils.ts";
 
 /** Return values for getting the first value of a query param. */
 type ParamValuesGet<Params extends object> = {

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,4 @@
-import type { JSONLike, TextLike } from "./type-utils.js";
+import type { JSONLike, TextLike } from "./type-utils.ts";
 
 /** A type-safe request helper that enhances native body methods based on the given OpenAPI spec. */
 export interface OpenApiRequest<RequestMap> extends Request {

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -11,10 +11,10 @@ import type {
   RequestMap,
   ResponseBody,
   ResponseMap,
-} from "./api-spec.js";
-import { QueryParams as QueryParamsUtil } from "./query-params.js";
-import type { OpenApiRequest } from "./request.js";
-import { createResponseHelper, type OpenApiResponse } from "./response.js";
+} from "./api-spec.ts";
+import { QueryParams as QueryParamsUtil } from "./query-params.ts";
+import type { OpenApiRequest } from "./request.ts";
+import { createResponseHelper, type OpenApiResponse } from "./response.ts";
 
 /** Response resolver that gets provided to HTTP handler factories. */
 export type ResponseResolver<

--- a/src/response.ts
+++ b/src/response.ts
@@ -4,8 +4,8 @@ import {
   type HttpResponseInit,
   type StrictResponse,
 } from "msw";
-import type { Wildcard } from "./http-status-wildcard.js";
-import type { JSONLike, NoContent, TextLike } from "./type-utils.js";
+import type { Wildcard } from "./http-status-wildcard.ts";
+import type { JSONLike, NoContent, TextLike } from "./type-utils.ts";
 
 /**
  * Requires or removes the status code from {@linkcode HttpResponseInit} depending

--- a/test/http-methods.test-d.ts
+++ b/test/http-methods.test-d.ts
@@ -1,6 +1,6 @@
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expectTypeOf, test } from "vitest";
-import type { paths } from "./fixtures/http-methods.api.js";
+import type { paths } from "./fixtures/http-methods.api.ts";
 
 describe("Given an OpenAPI endpoint with multiple HTTP methods", () => {
   const http = createOpenApiHttp<paths>();

--- a/test/http-utilities.test-d.ts
+++ b/test/http-utilities.test-d.ts
@@ -5,7 +5,7 @@ import {
   type ResponseBodyFor,
 } from "openapi-msw";
 import { describe, expectTypeOf, test } from "vitest";
-import type { paths } from "./fixtures/http-utilities.api.js";
+import type { paths } from "./fixtures/http-utilities.api.ts";
 
 describe("Given an OpenApiHttpHandlers namespace", () => {
   const http = createOpenApiHttp<paths>();

--- a/test/no-content.test-d.ts
+++ b/test/no-content.test-d.ts
@@ -1,7 +1,7 @@
 import { type StrictResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expectTypeOf, test } from "vitest";
-import type { paths } from "./fixtures/no-content.api.js";
+import type { paths } from "./fixtures/no-content.api.ts";
 
 describe("Given an OpenAPI schema endpoint with no-content", () => {
   const http = createOpenApiHttp<paths>();

--- a/test/no-content.test.ts
+++ b/test/no-content.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponse, type StrictResponse, getResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expect, test } from "vitest";
-import type { paths } from "./fixtures/no-content.api.js";
+import type { paths } from "./fixtures/no-content.api.ts";
 
 describe("Given an OpenAPI schema endpoint with no-content", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expect, test } from "vitest";
-import type { paths } from "./fixtures/options.api.js";
+import type { paths } from "./fixtures/options.api.ts";
 
 describe("Given a created HTTP object with options", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "http://localhost:3000" });

--- a/test/path-fragments.test-d.ts
+++ b/test/path-fragments.test-d.ts
@@ -1,6 +1,6 @@
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expectTypeOf, test } from "vitest";
-import type { paths } from "./fixtures/path-fragments.api.js";
+import type { paths } from "./fixtures/path-fragments.api.ts";
 
 describe("Given an OpenAPI schema endpoint that contains path fragments", () => {
   const http = createOpenApiHttp<paths>();

--- a/test/path-fragments.test.ts
+++ b/test/path-fragments.test.ts
@@ -1,7 +1,7 @@
 import { getResponse, HttpResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expect, test } from "vitest";
-import type { paths } from "./fixtures/path-fragments.api.js";
+import type { paths } from "./fixtures/path-fragments.api.ts";
 
 describe("Given an OpenAPI schema endpoint that contains path fragments", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });

--- a/test/query-params.test-d.ts
+++ b/test/query-params.test-d.ts
@@ -1,6 +1,6 @@
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expectTypeOf, test } from "vitest";
-import type { paths } from "./fixtures/query-params.api.js";
+import type { paths } from "./fixtures/query-params.api.ts";
 
 describe("Given an OpenAPI schema endpoint with query parameters fragments", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });

--- a/test/query-params.test.ts
+++ b/test/query-params.test.ts
@@ -1,7 +1,7 @@
 import { getResponse, HttpResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expect, test } from "vitest";
-import type { paths } from "./fixtures/query-params.api.js";
+import type { paths } from "./fixtures/query-params.api.ts";
 
 describe("Given an OpenAPI schema endpoint with query parameters fragments", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });

--- a/test/request-body.test-d.ts
+++ b/test/request-body.test-d.ts
@@ -1,7 +1,7 @@
 import { type StrictRequest } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expectTypeOf, test } from "vitest";
-import type { paths } from "./fixtures/request-body.api.js";
+import type { paths } from "./fixtures/request-body.api.ts";
 
 describe("Given an OpenAPI schema endpoint with request content", () => {
   const http = createOpenApiHttp<paths>();

--- a/test/request-body.test.ts
+++ b/test/request-body.test.ts
@@ -1,7 +1,7 @@
 import { getResponse, HttpResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expect, test } from "vitest";
-import type { paths } from "./fixtures/request-body.api.js";
+import type { paths } from "./fixtures/request-body.api.ts";
 
 describe("Given an OpenAPI schema endpoint with request content", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });

--- a/test/response-content.test-d.ts
+++ b/test/response-content.test-d.ts
@@ -1,7 +1,7 @@
 import { type StrictResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expectTypeOf, test } from "vitest";
-import type { paths } from "./fixtures/response-content.api.js";
+import type { paths } from "./fixtures/response-content.api.ts";
 
 describe("Given an OpenAPI schema endpoint with response content", () => {
   const http = createOpenApiHttp<paths>();

--- a/test/response-content.test.ts
+++ b/test/response-content.test.ts
@@ -1,7 +1,7 @@
 import { getResponse, HttpResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
 import { describe, expect, test } from "vitest";
-import type { paths } from "./fixtures/response-content.api.js";
+import type { paths } from "./fixtures/response-content.api.ts";
 
 describe("Given an OpenAPI schema endpoint with response content", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     /* Language and Environment */
     "target": "ESNext",
-    "lib": ["ESNext", "DOM"],
     "skipLibCheck": true,
 
     /* Modules */
@@ -13,6 +12,8 @@
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
     "erasableSyntaxOnly": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
 
     /* Type Checking */
     "strict": true,


### PR DESCRIPTION
Node.js is no able to execute TS files directly without printing any experimental warnings. However, it requires all relative imports to TS files to have a ".ts" extension as well.

To be able to quickly execute some script in the sources, this PR changes all relative imports from `*.js` to `*.ts`. This makes this codebase fully compatible with Node.js's (and Deno's) TypeScript support.