### PR TITLE
refactor!: bump MSW peer dependency and overhaul failing test suite

### DIFF
--- a/.changeset/wise-roses-cheer.md
+++ b/.changeset/wise-roses-cheer.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": major
+---
+
+Updated MSW peer dependency from v2.7.0 to v2.10.4. This is only a breaking change if you are not already using the latest version of MSW.

--- a/.changeset/wise-roses-cheer.md
+++ b/.changeset/wise-roses-cheer.md
@@ -2,4 +2,4 @@
 "openapi-msw": major
 ---
 
-Updated MSW peer dependency from v2.7.0 to v2.10.4. This is only a breaking change if you are not already using the latest version of MSW.
+Updated MSW peer dependency from v2.7.0 to v2.10.5. This is only a breaking change if you are not already using the latest version of MSW.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,16 +12,16 @@
         "@changesets/changelog-github": "^0.5.1",
         "@changesets/cli": "^2.29.5",
         "eslint": "^9.33.0",
-        "lefthook": "^1.12.2",
-        "openapi-typescript": "^7.9.0",
+        "lefthook": "^1.12.3",
+        "openapi-typescript": "^7.9.1",
         "prettier": "^3.6.2",
         "prettier-plugin-organize-imports": "^4.2.0",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.39.0",
+        "typescript-eslint": "^8.39.1",
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "msw": "^2.7.0"
+        "msw": "^2.10.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1198,9 +1198,9 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.37.5",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
-      "integrity": "sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==",
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.6.tgz",
+      "integrity": "sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1717,17 +1717,17 @@
       "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.0.tgz",
-      "integrity": "sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
+      "integrity": "sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/type-utils": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/type-utils": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1741,7 +1741,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.39.0",
+        "@typescript-eslint/parser": "^8.39.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -1757,16 +1757,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.0.tgz",
-      "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.1.tgz",
+      "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1782,14 +1782,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.0.tgz",
-      "integrity": "sha512-CTzJqaSq30V/Z2Og9jogzZt8lJRR5TKlAdXmWgdu4hgcC9Kww5flQ+xFvMxIBWVNdxJO7OifgdOK4PokMIWPew==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.1.tgz",
+      "integrity": "sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.39.0",
-        "@typescript-eslint/types": "^8.39.0",
+        "@typescript-eslint/tsconfig-utils": "^8.39.1",
+        "@typescript-eslint/types": "^8.39.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1804,14 +1804,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.0.tgz",
-      "integrity": "sha512-8QOzff9UKxOh6npZQ/4FQu4mjdOCGSdO3p44ww0hk8Vu+IGbg0tB/H1LcTARRDzGCC8pDGbh2rissBuuoPgH8A==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.1.tgz",
+      "integrity": "sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0"
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1822,9 +1822,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.0.tgz",
-      "integrity": "sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.1.tgz",
+      "integrity": "sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1839,15 +1839,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.0.tgz",
-      "integrity": "sha512-6B3z0c1DXVT2vYA9+z9axjtc09rqKUPRmijD5m9iv8iQpHBRYRMBcgxSiKTZKm6FwWw1/cI4v6em35OsKCiN5Q==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.1.tgz",
+      "integrity": "sha512-gu9/ahyatyAdQbKeHnhT4R+y3YLtqqHyvkfDxaBYk97EcbfChSJXyaJnIL3ygUv7OuZatePHmQvuH5ru0lnVeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1864,9 +1864,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.0.tgz",
-      "integrity": "sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1878,16 +1878,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.0.tgz",
-      "integrity": "sha512-ndWdiflRMvfIgQRpckQQLiB5qAKQ7w++V4LlCHwp62eym1HLB/kw7D9f2e8ytONls/jt89TEasgvb+VwnRprsw==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
+      "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.39.0",
-        "@typescript-eslint/tsconfig-utils": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
+        "@typescript-eslint/project-service": "8.39.1",
+        "@typescript-eslint/tsconfig-utils": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1933,16 +1933,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.0.tgz",
-      "integrity": "sha512-4GVSvNA0Vx1Ktwvf4sFE+exxJ3QGUorQG1/A5mRfRNZtkBT2xrA/BCO2H0eALx/PnvCS6/vmYwRdDA41EoffkQ==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.1.tgz",
+      "integrity": "sha512-VF5tZ2XnUSTuiqZFXCZfZs1cgkdd3O/sSYmdo2EpSyDlC86UM/8YytTmKnehOW3TGAlivqTDT6bS87B/GQ/jyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0"
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1957,13 +1957,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.0.tgz",
-      "integrity": "sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
+      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
+        "@typescript-eslint/types": "8.39.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -3481,9 +3481,9 @@
       }
     },
     "node_modules/lefthook": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.12.2.tgz",
-      "integrity": "sha512-2CeTu5NcmoT9YnqsHTq/TF36MlqlzHzhivGx3DrXHwcff4TdvrkIwUTA56huM3Nlo5ODAF/0hlPzaKLmNHCBnQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.12.3.tgz",
+      "integrity": "sha512-huMg+mGp6wHPjkaLdchuOvxVRMzvz6OVdhivatiH2Qn47O5Zm46jwzbVPYIanX6N/8ZTjGLBxv8tZ0KYmKt/Jg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3491,22 +3491,22 @@
         "lefthook": "bin/index.js"
       },
       "optionalDependencies": {
-        "lefthook-darwin-arm64": "1.12.2",
-        "lefthook-darwin-x64": "1.12.2",
-        "lefthook-freebsd-arm64": "1.12.2",
-        "lefthook-freebsd-x64": "1.12.2",
-        "lefthook-linux-arm64": "1.12.2",
-        "lefthook-linux-x64": "1.12.2",
-        "lefthook-openbsd-arm64": "1.12.2",
-        "lefthook-openbsd-x64": "1.12.2",
-        "lefthook-windows-arm64": "1.12.2",
-        "lefthook-windows-x64": "1.12.2"
+        "lefthook-darwin-arm64": "1.12.3",
+        "lefthook-darwin-x64": "1.12.3",
+        "lefthook-freebsd-arm64": "1.12.3",
+        "lefthook-freebsd-x64": "1.12.3",
+        "lefthook-linux-arm64": "1.12.3",
+        "lefthook-linux-x64": "1.12.3",
+        "lefthook-openbsd-arm64": "1.12.3",
+        "lefthook-openbsd-x64": "1.12.3",
+        "lefthook-windows-arm64": "1.12.3",
+        "lefthook-windows-x64": "1.12.3"
       }
     },
     "node_modules/lefthook-darwin-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.12.2.tgz",
-      "integrity": "sha512-fTxeI9tEskrHjc3QyEO+AG7impBXY2Ed8V5aiRc3fw9POfYtVh9b5jRx90fjk2+ld5hf+Z1DsyyLq/vOHDFskQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.12.3.tgz",
+      "integrity": "sha512-j1lwaosWRy3vhz8oQgCS1M6EUFN95aIYeNuqkczsBoAA6BDNAmVP1ctYEIYUK4bYaIgENbqbA9prYMAhyzh6Og==",
       "cpu": [
         "arm64"
       ],
@@ -3518,9 +3518,9 @@
       ]
     },
     "node_modules/lefthook-darwin-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.12.2.tgz",
-      "integrity": "sha512-T1dCDKAAfdHgYZ8qtrS02SJSHoR52RFcrGArFNll9Mu4ZSV19Sp8BO+kTwDUOcLYdcPGNaqOp9PkRBQGZWQC7g==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.12.3.tgz",
+      "integrity": "sha512-x6aWFfLQX4m5zQ4X9zh5+hHOE5XTvNjz2zB9DI+xbIBLs2RRg0xJNT3OfgSrBU1QtEBneJ5dRQP5nl47td9GDQ==",
       "cpu": [
         "x64"
       ],
@@ -3532,9 +3532,9 @@
       ]
     },
     "node_modules/lefthook-freebsd-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.12.2.tgz",
-      "integrity": "sha512-2n9z7Q4BKeMBoB9cuEdv0UBQH82Z4GgBQpCrfjCtyzpDnYQwrH8Tkrlnlko4qPh9MM6nLLGIYMKsA5nltzo8Cg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.12.3.tgz",
+      "integrity": "sha512-41OmulLqVZ0EOHmmHouJrpL59SwDD7FLoso4RsQVIBPaf8fHacdLo07Ye28VWQ5XolZQvnWcr1YXKo4JhqQMyw==",
       "cpu": [
         "arm64"
       ],
@@ -3546,9 +3546,9 @@
       ]
     },
     "node_modules/lefthook-freebsd-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.12.2.tgz",
-      "integrity": "sha512-1hNY/irY+/3kjRzKoJYxG+m3BYI8QxopJUK1PQnknGo1Wy5u302SdX+tR7pnpz6JM5chrNw4ozSbKKOvdZ5VEw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.12.3.tgz",
+      "integrity": "sha512-741/JRCJIS++hgYEH2uefN4FsH872V7gy2zDhcfQofiZnWP7+qhl4Wmwi8IpjIu4X7hLOC4cT18LOVU5L8KV9Q==",
       "cpu": [
         "x64"
       ],
@@ -3560,9 +3560,9 @@
       ]
     },
     "node_modules/lefthook-linux-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.12.2.tgz",
-      "integrity": "sha512-1W4swYIVRkxq/LFTuuK4oVpd6NtTKY4E3VY2Uq2JDkIOJV46+8qGBF+C/QA9K3O9chLffgN7c+i+NhIuGiZ/Vw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.12.3.tgz",
+      "integrity": "sha512-BXIy1aDFZmFgmebJliNrEqZfX1lSOD4b/USvANv1UirFrNgTq5SRssd1CKfflT2PwKX6LsJTD4WabLLWZOxp9A==",
       "cpu": [
         "arm64"
       ],
@@ -3574,9 +3574,9 @@
       ]
     },
     "node_modules/lefthook-linux-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.12.2.tgz",
-      "integrity": "sha512-J6VGuMfhq5iCsg1Pv7xULbuXC63gP5LaikT0PhkyBNMi3HQneZFDJ8k/sp0Ue9HkQv6QfWIo3/FgB9gz38MCFw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.12.3.tgz",
+      "integrity": "sha512-FRdwdj5jsQAP2eVrtkVUqMqYNCbQ2Ix84izy29/BvLlu/hVypAGbDfUkgFnsmAd6ZsCBeYCEtPuqyg3E3SO0Rg==",
       "cpu": [
         "x64"
       ],
@@ -3588,9 +3588,9 @@
       ]
     },
     "node_modules/lefthook-openbsd-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.12.2.tgz",
-      "integrity": "sha512-wncDRW3ml24DaOyH22KINumjvCohswbQqbxyH2GORRCykSnE859cTjOrRIchTKBIARF7PSeGPUtS7EK0+oDbaw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.12.3.tgz",
+      "integrity": "sha512-tch5wXY4GOjKAYohH7OFoxNdVHuUSYt2Pulo2VTkMYEG8IrvJnRO5MkvgHtKDHzU5mfABQYv5+ccJykDx5hQWA==",
       "cpu": [
         "arm64"
       ],
@@ -3602,9 +3602,9 @@
       ]
     },
     "node_modules/lefthook-openbsd-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.12.2.tgz",
-      "integrity": "sha512-2jDOkCHNnc/oK/vR62hAf3vZb1EQ6Md2GjIlgZ/V7A3ztOsM8QZ5IxwYN3D1UOIR5ZnwMBy7PtmTJC/HJrig5w==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.12.3.tgz",
+      "integrity": "sha512-IHbHg/rUFXrAN7LnjcQEtutCHBaD49CZge96Hpk0GZ2eEG5GTCNRnUyEf+Kf3+RTqHFgwtADdpeDa/ZaGZTM4g==",
       "cpu": [
         "x64"
       ],
@@ -3616,9 +3616,9 @@
       ]
     },
     "node_modules/lefthook-windows-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.12.2.tgz",
-      "integrity": "sha512-ZMH/q6UNSidhHEG/1QoqIl1n4yPTBWuVmKx5bONtKHicoz4QCQ+QEiNjKsG5OO4C62nfyHGThmweCzZVUQECJw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.12.3.tgz",
+      "integrity": "sha512-wghcE5TSpb+mbtemUV6uAo9hEK09kxRzhf2nPdeDX+fw42cL2TGZsbaCnDyzaY144C+L2/wEWrLIHJMnZYkuqA==",
       "cpu": [
         "arm64"
       ],
@@ -3630,9 +3630,9 @@
       ]
     },
     "node_modules/lefthook-windows-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.12.2.tgz",
-      "integrity": "sha512-TqT2jIPcTQ9uwaw+v+DTmvnUHM/p7bbsSrPoPX+fRXSGLzFjyiY+12C9dObSwfCQq6rT70xqQJ9AmftJQsa5/Q==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.12.3.tgz",
+      "integrity": "sha512-7Co/L8e2x2hGC1L33jDJ4ZlTkO3PJm25GOGpLfN1kqwhGB/uzMLeTI/PBczjlIN8isUv26ouNd9rVR7Bibrwyg==",
       "cpu": [
         "x64"
       ],
@@ -3756,9 +3756,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.0.tgz",
-      "integrity": "sha512-BIodwZ19RWfCbYTxWTUfTXc+sg4OwjCAgxU1ZsgmggX/7S3LdUifsbUPJs61j0rWb19CZRGY5if77duhc0uXzw==",
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.10.5.tgz",
+      "integrity": "sha512-0EsQCrCI1HbhpBWd89DvmxY6plmvrM96b0sCIztnvcNHQbXn5vqwm1KlXslo6u4wN9LFGLC1WFjjgljcQhe40A==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -3767,7 +3767,7 @@
         "@bundled-es-modules/statuses": "^1.0.1",
         "@bundled-es-modules/tough-cookie": "^0.1.6",
         "@inquirer/confirm": "^5.0.0",
-        "@mswjs/interceptors": "^0.37.0",
+        "@mswjs/interceptors": "^0.39.1",
         "@open-draft/deferred-promise": "^2.2.0",
         "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
@@ -3858,9 +3858,9 @@
       }
     },
     "node_modules/openapi-typescript": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.9.0.tgz",
-      "integrity": "sha512-y0MWNGQgS8VvxaU2fIqb9bKTacxJUGoCqhgpYRlO3NvnMEWjJ8lI3EuFnTsK7nIMiYj7Jobr0WY1G79spK4Q6w==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.9.1.tgz",
+      "integrity": "sha512-9gJtoY04mk6iPMbToPjPxEAtfXZ0dTsMZtsgUI8YZta0btPPig9DJFP4jlerQD/7QOwYgb0tl+zLUpDf7vb7VA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4770,16 +4770,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.0.tgz",
-      "integrity": "sha512-lH8FvtdtzcHJCkMOKnN73LIn6SLTpoojgJqDAxPm1jCR14eWSGPX8ul/gggBdPMk/d5+u9V854vTYQ8T5jF/1Q==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.1.tgz",
+      "integrity": "sha512-GDUv6/NDYngUlNvwaHM1RamYftxf782IyEDbdj3SeaIHHv8fNQVRC++fITT7kUJV/5rIA/tkoRSSskt6osEfqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.39.0",
-        "@typescript-eslint/parser": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0"
+        "@typescript-eslint/eslint-plugin": "8.39.1",
+        "@typescript-eslint/parser": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -34,18 +34,18 @@
     "release": "changeset publish"
   },
   "peerDependencies": {
-    "msw": "^2.7.0"
+    "msw": "^2.10.5"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.29.5",
     "eslint": "^9.33.0",
-    "lefthook": "^1.12.2",
-    "openapi-typescript": "^7.9.0",
+    "lefthook": "^1.12.3",
+    "openapi-typescript": "^7.9.1",
     "prettier": "^3.6.2",
     "prettier-plugin-organize-imports": "^4.2.0",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.39.0",
+    "typescript-eslint": "^8.39.1",
     "vitest": "^3.2.4"
   }
 }

--- a/src/openapi-http.test.ts
+++ b/src/openapi-http.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { http as mswHttp } from "msw";
-import { describe, expect, it, vi } from "vitest";
+import { expect, suite, test, vi } from "vitest";
 import type { HttpMethod } from "./api-spec.ts";
 import { createOpenApiHttp } from "./openapi-http.ts";
 
@@ -14,8 +14,8 @@ const methods: HttpMethod[] = [
   "patch",
 ];
 
-describe(createOpenApiHttp, () => {
-  it("should create an http handlers object", () => {
+suite(createOpenApiHttp, () => {
+  test("creates an http handlers object", () => {
     const http = createOpenApiHttp();
 
     expect(http).toBeTypeOf("object");
@@ -24,15 +24,15 @@ describe(createOpenApiHttp, () => {
     }
   });
 
-  it("should include the original MSW methods in its return type", () => {
+  test("includes the original MSW methods in its return type", () => {
     const http = createOpenApiHttp();
 
     expect(http.untyped).toBe(mswHttp);
   });
 });
 
-describe.each(methods)("openapi %s http handlers", (method) => {
-  it("should forward its arguments to MSW", () => {
+suite.each(methods)("OpenAPI %s http handlers", (method) => {
+  test("forwards its arguments to MSW", () => {
     using spy = vi.spyOn(mswHttp, method);
     const resolver = vi.fn();
 
@@ -45,7 +45,7 @@ describe.each(methods)("openapi %s http handlers", (method) => {
     });
   });
 
-  it("should convert openapi paths to MSW compatible paths", () => {
+  test("converts OpenAPI paths to MSW compatible paths", () => {
     using spy = vi.spyOn(mswHttp, method);
     const resolver = vi.fn();
 
@@ -60,7 +60,7 @@ describe.each(methods)("openapi %s http handlers", (method) => {
     );
   });
 
-  it("should prepend a configured baseUrl to the path for MSW", () => {
+  test("prepends a configured baseUrl to the path for MSW", () => {
     using spy = vi.spyOn(mswHttp, method);
     const resolver = vi.fn();
 

--- a/src/path-mapping.test.ts
+++ b/src/path-mapping.test.ts
@@ -1,26 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { expect, suite, test } from "vitest";
 import { convertToColonPath } from "./path-mapping.ts";
 
-describe(convertToColonPath, () => {
-  it("should leave paths with no path fragments untouched", () => {
+suite(convertToColonPath, () => {
+  test("leaves paths with no path fragments untouched", () => {
     const result = convertToColonPath("/users");
 
     expect(result).toBe("/users");
   });
 
-  it("should convert a path fragment to colon convention", () => {
+  test("converts a path fragment to colon convention", () => {
     const result = convertToColonPath("/users/{id}");
 
     expect(result).toBe("/users/:id");
   });
 
-  it("should convert all fragments in a path to colon convention", () => {
+  test("converts all fragments in a path to colon convention", () => {
     const result = convertToColonPath("/users/{userId}/posts/{postIds}");
 
     expect(result).toBe("/users/:userId/posts/:postIds");
   });
 
-  it("should append a baseUrl to the path when provided", () => {
+  test("appends a baseUrl to the path when provided", () => {
     const noBaseUrl = convertToColonPath("/users");
     const withBaseUrl = convertToColonPath("/users", "https://localhost:3000");
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,9 +1,4 @@
-import {
-  HttpResponse,
-  type DefaultBodyType,
-  type HttpResponseInit,
-  type StrictResponse,
-} from "msw";
+import { HttpResponse, type DefaultBodyType, type HttpResponseInit } from "msw";
 import type { Wildcard } from "./http-status-wildcard.ts";
 import type { JSONLike, NoContent, TextLike } from "./type-utils.ts";
 
@@ -26,18 +21,18 @@ interface ResponseInitForWildcard<Key extends keyof Wildcard>
 type TextResponse<ResponseBody, Status> = (
   body: ResponseBody extends string ? ResponseBody : never,
   init: DynamicResponseInit<Status>,
-) => StrictResponse<typeof body>;
+) => HttpResponse<typeof body>;
 
 /** Creates a type-safe json response, which may require an additional status code. */
 type JsonResponse<ResponseBody, Status> = (
   body: ResponseBody extends DefaultBodyType ? ResponseBody : never,
   init: DynamicResponseInit<Status>,
-) => StrictResponse<typeof body>;
+) => HttpResponse<typeof body>;
 
 /** Creates a type-safe empty response, which may require an additional status code. */
 type EmptyResponse<Status> = (
   init: DynamicResponseInit<Status>,
-) => StrictResponse<null>;
+) => HttpResponse<null>;
 
 /**
  * A type-safe response helper that narrows available status codes and content types,
@@ -63,7 +58,7 @@ export interface OpenApiResponse<
       ? unknown
       : EmptyResponse<Status>;
   };
-  untyped(response: Response): StrictResponse<ExpectedResponseBody>;
+  untyped(response: Response): HttpResponse<ExpectedResponseBody>;
 }
 
 export function createResponseHelper<
@@ -98,14 +93,14 @@ export function createResponseHelper<
         status: status as number,
         ...init,
         headers,
-      }) as StrictResponse<null>;
+      });
     };
 
     return { text, json, empty };
   };
 
   response.untyped = (response) => {
-    return response as StrictResponse<ExpectedResponseBody>;
+    return response as HttpResponse<ExpectedResponseBody>;
   };
 
   return response;

--- a/test/http-methods.test-d.ts
+++ b/test/http-methods.test-d.ts
@@ -1,57 +1,58 @@
 import { createOpenApiHttp } from "openapi-msw";
-import { describe, expectTypeOf, test } from "vitest";
+import { expectTypeOf, suite, test } from "vitest";
 import type { paths } from "./fixtures/http-methods.api.ts";
 
-describe("Given an OpenAPI endpoint with multiple HTTP methods", () => {
+suite("Calling HTTP methods", () => {
   const http = createOpenApiHttp<paths>();
 
-  test("When the GET method is mocked, Then only paths with GET methods are allowed", () => {
+  test("expects only GET methods when 'get' is called", () => {
     const path = expectTypeOf<typeof http.get>().parameter(0);
 
     path.toEqualTypeOf<"/resource" | "/resource/get">();
   });
 
-  test("When the PUT method is mocked, Then only paths with PUT methods are allowed", () => {
+  test("expects only PUT methods when 'put' is called", () => {
     const path = expectTypeOf<typeof http.put>().parameter(0);
 
     path.toEqualTypeOf<"/resource" | "/resource/put">();
   });
 
-  test("When the POST method is mocked, Then only paths with POST methods are allowed", () => {
+  test("expects only POST methods when 'post' is called", () => {
     const path = expectTypeOf<typeof http.post>().parameter(0);
 
     path.toEqualTypeOf<"/resource" | "/resource/post">();
   });
 
-  test("When the PATCH method is mocked, Then only paths with PATCH methods are allowed", () => {
+  test("expects only PATCH methods when 'patch' is called", () => {
     const path = expectTypeOf<typeof http.patch>().parameter(0);
 
     path.toEqualTypeOf<"/resource" | "/resource/patch">();
   });
 
-  test("When the DELETE method is mocked, Then only paths with DELETE methods are allowed", () => {
+  test("expects only DELETE methods when 'delete' is called", () => {
     const path = expectTypeOf<typeof http.delete>().parameter(0);
 
     path.toEqualTypeOf<"/resource" | "/resource/delete">();
   });
 
-  test("When the OPTIONS method is mocked, Then only paths with OPTIONS methods are allowed", () => {
+  test("expects only OPTIONS methods when 'options' is called", () => {
     const path = expectTypeOf<typeof http.options>().parameter(0);
 
     path.toEqualTypeOf<"/resource">();
   });
 
-  test("When the HEAD method is mocked, Then only paths with HEAD methods are allowed", () => {
+  test("expects only HEAD methods when 'head' is called", () => {
     const path = expectTypeOf<typeof http.head>().parameter(0);
 
     path.toEqualTypeOf<"/resource">();
   });
 
-  test("When the vanilla HTTP fallback is used, Then any path value is allowed", () => {
-    const extractPath = (method: keyof typeof http.untyped) =>
-      expectTypeOf<(typeof http.untyped)[typeof method]>()
+  test("expects any string when the untyped HTTP fallback is used", () => {
+    const extractPath = (method: keyof typeof http.untyped) => {
+      return expectTypeOf<(typeof http.untyped)[typeof method]>()
         .parameter(0)
         .extract<string>();
+    };
 
     extractPath("all").toEqualTypeOf<string>();
     extractPath("get").toEqualTypeOf<string>();

--- a/test/http-utilities.test-d.ts
+++ b/test/http-utilities.test-d.ts
@@ -4,19 +4,19 @@ import {
   type RequestBodyFor,
   type ResponseBodyFor,
 } from "openapi-msw";
-import { describe, expectTypeOf, test } from "vitest";
+import { expectTypeOf, suite, test } from "vitest";
 import type { paths } from "./fixtures/http-utilities.api.ts";
 
-describe("Given an OpenApiHttpHandlers namespace", () => {
+suite("Using request-handler utilities", () => {
   const http = createOpenApiHttp<paths>();
 
-  test("When paths are extracted, Then a path union is returned", () => {
+  test("extracts the expected path union from a request handler", () => {
     const result = expectTypeOf<PathsFor<typeof http.get>>();
 
     result.toEqualTypeOf<"/resource" | "/resource/{id}">();
   });
 
-  test("When the request body is extracted, Then the request body is returned", () => {
+  test("extracts the request body from a request handler", () => {
     const result =
       expectTypeOf<RequestBodyFor<typeof http.post, "/resource">>();
     const resultNoBody =
@@ -26,7 +26,7 @@ describe("Given an OpenApiHttpHandlers namespace", () => {
     resultNoBody.toEqualTypeOf<never>();
   });
 
-  test("When the response body is extracted, Then the response body is returned", () => {
+  test("extracts the response body from a request handler", () => {
     const result =
       expectTypeOf<ResponseBodyFor<typeof http.get, "/resource">>();
     const resultNoBody =

--- a/test/no-content.test-d.ts
+++ b/test/no-content.test-d.ts
@@ -1,36 +1,30 @@
-import { type StrictResponse } from "msw";
+import type { AsyncResponseResolverReturnType } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
-import { describe, expectTypeOf, test } from "vitest";
+import { expectTypeOf, suite, test } from "vitest";
 import type { paths } from "./fixtures/no-content.api.ts";
 
-describe("Given an OpenAPI schema endpoint with no-content", () => {
+suite("Mocking no-content routes", () => {
   const http = createOpenApiHttp<paths>();
 
-  test("When an endpoint is mocked, Then responses with content cannot be returned", async () => {
+  test("expect a response with an empty body", () => {
     type Endpoint = typeof http.delete<"/resource">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
-    const response = resolver.returns.extract<Response>();
+    const response = resolver.returns;
 
-    response.not.toEqualTypeOf<StrictResponse<{ id: number }>>();
+    response.toEqualTypeOf<AsyncResponseResolverReturnType<null>>();
   });
 
-  test("When an endpoint is mocked, Then responses must be strict responses", async () => {
-    type Endpoint = typeof http.delete<"/resource">;
-    const resolver = expectTypeOf<Endpoint>().parameter(1);
-    const response = resolver.returns.extract<Response>();
-
-    response.not.toEqualTypeOf<Response>();
-    response.toEqualTypeOf<StrictResponse<null>>();
-  });
-
-  test("When a endpoint with a NoContent response is mocked, Then the no-content option is included in the response union", async () => {
+  test("combines multiple status codes with content and no-content into a response union", () => {
     type Endpoint = typeof http.get<"/no-content-resource">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
-    const response = resolver.returns.extract<Response>();
+    const response = resolver.returns;
 
-    response.not.toEqualTypeOf<Response>();
     response.toEqualTypeOf<
-      StrictResponse<{ id: string; name: string; value: number } | null>
+      AsyncResponseResolverReturnType<{
+        id: string;
+        name: string;
+        value: number;
+      } | null>
     >();
   });
 });

--- a/test/no-content.test-d.ts
+++ b/test/no-content.test-d.ts
@@ -6,7 +6,7 @@ import type { paths } from "./fixtures/no-content.api.ts";
 suite("Mocking no-content routes", () => {
   const http = createOpenApiHttp<paths>();
 
-  test("expect a response with an empty body", () => {
+  test("expects a response with an empty body", () => {
     type Endpoint = typeof http.delete<"/resource">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const response = resolver.returns;

--- a/test/no-content.test.ts
+++ b/test/no-content.test.ts
@@ -1,36 +1,36 @@
-import { HttpResponse, type StrictResponse, getResponse } from "msw";
+import { HttpResponse, getResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
-import { describe, expect, test } from "vitest";
+import { expect, suite, test } from "vitest";
 import type { paths } from "./fixtures/no-content.api.ts";
 
-describe("Given an OpenAPI schema endpoint with no-content", () => {
+suite("Mocking no-content routes", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });
 
-  test("When the DELETE method is mocked, Then empty responses can be returned", async () => {
-    const request = new Request(new URL("/resource", "http://localhost:3000"), {
+  test("returns responses with an empty body for DELETE requests", async () => {
+    const request = new Request("http://localhost:3000/resource", {
       method: "delete",
     });
 
     const handler = http.delete("/resource", () => {
-      return new HttpResponse(null, { status: 204 }) as StrictResponse<null>;
+      return new HttpResponse(null, { status: 204 });
     });
     const response = await getResponse([handler], request);
 
-    expect(response?.body).toBeNull();
     expect(response?.status).toBe(204);
+    expect(response?.body).toBeNull();
   });
 
-  test("When the POST method is mocked, Then empty responses can be returned", async () => {
-    const request = new Request(new URL("/resource", "http://localhost:3000"), {
+  test("returns responses with an empty body for POST requests", async () => {
+    const request = new Request("http://localhost:3000/resource", {
       method: "post",
     });
 
     const handler = http.post("/resource", () => {
-      return new HttpResponse(null, { status: 201 }) as StrictResponse<null>;
+      return new HttpResponse(null, { status: 201 });
     });
     const response = await getResponse([handler], request);
 
-    expect(response?.body).toBeNull();
     expect(response?.status).toBe(201);
+    expect(response?.body).toBeNull();
   });
 });

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,12 +1,12 @@
 import { HttpResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
-import { describe, expect, test } from "vitest";
+import { expect, suite, test } from "vitest";
 import type { paths } from "./fixtures/options.api.ts";
 
-describe("Given a created HTTP object with options", () => {
+suite("Providing HTTP factory options", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "http://localhost:3000" });
 
-  test("When a OpenAPI handler is created, Then the baseUrl is prepended to the path", async () => {
+  test("prepends a given baseUrl to the given path", () => {
     const handler = http.get("/resource", () => {
       return HttpResponse.json({ id: "test-id" });
     });
@@ -14,7 +14,7 @@ describe("Given a created HTTP object with options", () => {
     expect(handler.info.path).toBe("http://localhost:3000/resource");
   });
 
-  test("When a vanilla handler is created, Then the baseUrl is not prepended to the path", async () => {
+  test("does not prepend a given baseUrl for vanilla handlers", () => {
     const handler = http.untyped.get("/some-resource", () => {
       return HttpResponse.json();
     });

--- a/test/path-fragments.test-d.ts
+++ b/test/path-fragments.test-d.ts
@@ -1,11 +1,11 @@
 import { createOpenApiHttp } from "openapi-msw";
-import { describe, expectTypeOf, test } from "vitest";
+import { expectTypeOf, suite, test } from "vitest";
 import type { paths } from "./fixtures/path-fragments.api.ts";
 
-describe("Given an OpenAPI schema endpoint that contains path fragments", () => {
+suite("Mocking paths with fragments", () => {
   const http = createOpenApiHttp<paths>();
 
-  test("When an endpoint is mocked, Then the path fragments are strict-typed", () => {
+  test("provides strict-typed params", () => {
     type Endpoint = typeof http.get<"/resource/{id}/{name}">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const params = resolver.parameter(0).toHaveProperty("params");
@@ -13,7 +13,7 @@ describe("Given an OpenAPI schema endpoint that contains path fragments", () => 
     params.toEqualTypeOf<{ id: string; name: string }>();
   });
 
-  test("When a endpoint contains no path fragments, Then no params are provided", () => {
+  test("does not provide params for paths with no fragments", () => {
     type Endpoint = typeof http.get<"/resource">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const params = resolver.parameter(0).toHaveProperty("params");
@@ -21,7 +21,7 @@ describe("Given an OpenAPI schema endpoint that contains path fragments", () => 
     params.toEqualTypeOf<never>();
   });
 
-  test("When a path fragment is typed with non-string types, Then the type is converted to string", async () => {
+  test("converts non-string fragment types to string", () => {
     // The values passed in by MSW will always be strings at runtime.
     // Therefore, we convert to to enable runtime parsing, e.g. parseInt(...).
     type Endpoint = typeof http.get<"/resource/{count}">;
@@ -31,7 +31,7 @@ describe("Given an OpenAPI schema endpoint that contains path fragments", () => 
     params.toEqualTypeOf<{ count: string }>();
   });
 
-  test("When a path fragment is typed with string literals, Then the literals are preserved", async () => {
+  test("preserves string literal fragment types", () => {
     type Endpoint = typeof http.get<"/resource/{enum}">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const params = resolver.parameter(0).toHaveProperty("params");

--- a/test/path-fragments.test.ts
+++ b/test/path-fragments.test.ts
@@ -1,14 +1,14 @@
 import { getResponse, HttpResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
-import { describe, expect, test } from "vitest";
+import { expect, suite, test } from "vitest";
 import type { paths } from "./fixtures/path-fragments.api.ts";
 
-describe("Given an OpenAPI schema endpoint that contains path fragments", () => {
+suite("Mocking paths with fragments", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });
 
-  test("When a endpoint is mocked, Then OpenAPI path fragments can be parsed by the handler", async () => {
+  test("provides usable params to the resolver function", async () => {
     const request = new Request(
-      new URL("/resource/test-id/test-name", "http://localhost:3000"),
+      "http://localhost:3000/resource/test-id/test-name",
     );
 
     const handler = http.get("/resource/{id}/{name}", ({ params }) => {
@@ -21,15 +21,11 @@ describe("Given an OpenAPI schema endpoint that contains path fragments", () => 
     expect(responseBody?.name).toBe("test-name");
   });
 
-  test("When a path fragment is specified as a number, Then it can be parsed to a number", async () => {
-    const request = new Request(
-      new URL("/resource/42", "http://localhost:3000"),
-    );
+  test("can parse fragments as number when the fragment is specified as a number fragment", async () => {
+    const request = new Request("http://localhost:3000/resource/42");
 
     const handler = http.get("/resource/{count}", ({ params }) => {
-      const count = parseInt(params.count);
-
-      return HttpResponse.json({ count });
+      return HttpResponse.json({ count: parseInt(params.count) });
     });
     const response = await getResponse([handler], request);
 

--- a/test/query-params.test-d.ts
+++ b/test/query-params.test-d.ts
@@ -1,11 +1,11 @@
 import { createOpenApiHttp } from "openapi-msw";
-import { describe, expectTypeOf, test } from "vitest";
+import { expectTypeOf, suite, test } from "vitest";
 import type { paths } from "./fixtures/query-params.api.ts";
 
-describe("Given an OpenAPI schema endpoint with query parameters fragments", () => {
+suite("Using the query helper", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });
 
-  test("When a endpoint is mocked, Then search parameter keys are strict typed", () => {
+  test("provides strict-typed search-param names for endpoints with defined search-params", () => {
     http.get("/single-query", ({ query }) => {
       expectTypeOf(query.get)
         .parameter(0)
@@ -19,7 +19,7 @@ describe("Given an OpenAPI schema endpoint with query parameters fragments", () 
     });
   });
 
-  test("When a endpoint is mocked, Then search parameters are converted into their stringified version", () => {
+  test("converts search-param value types into stringified types", () => {
     http.get("/single-query", ({ query }) => {
       const sort = query.getAll("sort");
       const page = query.get("page");
@@ -31,7 +31,7 @@ describe("Given an OpenAPI schema endpoint with query parameters fragments", () 
     });
   });
 
-  test("When a endpoint is mocked, Then multiple search parameters are parsed from arrays", () => {
+  test("parses search-param value types from multi-param definitions", () => {
     http.get("/multi-query", ({ query }) => {
       const single = query.get("id");
       const multi = query.getAll("id");
@@ -45,7 +45,7 @@ describe("Given an OpenAPI schema endpoint with query parameters fragments", () 
     });
   });
 
-  test("When a endpoint with no query params is mocked, Then no query keys can be passed to the query helper", () => {
+  test("accepts no search-param names for endpoints with no defined search-params", () => {
     http.get("/no-query", ({ query }) => {
       expectTypeOf(query.get).parameter(0).toEqualTypeOf<never>();
       expectTypeOf(query.getAll).parameter(0).toEqualTypeOf<never>();

--- a/test/query-params.test.ts
+++ b/test/query-params.test.ts
@@ -1,18 +1,15 @@
 import { getResponse, HttpResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
-import { describe, expect, test } from "vitest";
+import { expect, suite, test } from "vitest";
 import type { paths } from "./fixtures/query-params.api.ts";
 
-describe("Given an OpenAPI schema endpoint with query parameters fragments", () => {
+suite("Using the query helper", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });
 
-  test("When a endpoint is mocked, Then query parameters can be accessed through a 'query' helper", async () => {
-    expect.assertions(4); // Make sure that assertion in handler is executed.
+  test("exposes type-safe search-param values in the response resolver", async () => {
+    expect.assertions(4); // Make sure that assertions in handler are executed.
     const request = new Request(
-      new URL(
-        "/single-query?page=3&sort=desc&query=test",
-        "http://localhost:3000",
-      ),
+      "http://localhost:3000/single-query?page=3&sort=desc&query=test",
     );
 
     const handler = http.get("/single-query", ({ query }) => {
@@ -31,10 +28,10 @@ describe("Given an OpenAPI schema endpoint with query parameters fragments", () 
     expect(response?.status).toBe(200);
   });
 
-  test("When a endpoint is mocked, Then multiple query parameters are grouped into an array", async () => {
+  test("aggregates multiple values for a search-param into an array", async () => {
     expect.assertions(2); // Make sure that assertion in handler is executed.
     const request = new Request(
-      new URL("/multi-query?id=1&id=2&id=3", "http://localhost:3000"),
+      "http://localhost:3000/multi-query?id=1&id=2&id=3",
     );
 
     const handler = http.get("/multi-query", ({ query }) => {

--- a/test/query-params.test.ts
+++ b/test/query-params.test.ts
@@ -7,7 +7,7 @@ suite("Using the query helper", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });
 
   test("exposes type-safe search-param values in the response resolver", async () => {
-    expect.assertions(4); // Make sure that assertions in handler are executed.
+    expect.assertions(4); // Make sure assertions in the handler are executed.
     const request = new Request(
       "http://localhost:3000/single-query?page=3&sort=desc&query=test",
     );
@@ -29,7 +29,7 @@ suite("Using the query helper", () => {
   });
 
   test("aggregates multiple values for a search-param into an array", async () => {
-    expect.assertions(2); // Make sure that assertion in handler is executed.
+    expect.assertions(2); // Make sure assertions in the handler are executed.
     const request = new Request(
       "http://localhost:3000/multi-query?id=1&id=2&id=3",
     );

--- a/test/request-body.test-d.ts
+++ b/test/request-body.test-d.ts
@@ -1,20 +1,20 @@
 import { type StrictRequest } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
-import { describe, expectTypeOf, test } from "vitest";
+import { expectTypeOf, suite, test } from "vitest";
 import type { paths } from "./fixtures/request-body.api.ts";
 
-describe("Given an OpenAPI schema endpoint with request content", () => {
+suite("Accessing requests bodies", () => {
   const http = createOpenApiHttp<paths>();
 
-  test("When the request is used, Then it extend MSW's request object", () => {
+  test("extends MSW's request object", () => {
     type Endpoint = typeof http.get<"/resource">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const request = resolver.parameter(0).toHaveProperty("request");
 
-    request.toMatchTypeOf<Omit<StrictRequest<null>, "text" | "json">>();
+    request.toExtend<StrictRequest<null>>();
   });
 
-  test("When a request is not expected to contain content, Then json and text return never", () => {
+  test("returns never when json() or text() is called for requests with no expected content", () => {
     type Endpoint = typeof http.get<"/resource">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const request = resolver.parameter(0).toHaveProperty("request");
@@ -23,7 +23,7 @@ describe("Given an OpenAPI schema endpoint with request content", () => {
     request.toHaveProperty("json").returns.toEqualTypeOf<never>();
   });
 
-  test("When a request is expected to contain content, Then the content is strict-typed", () => {
+  test("provides strict types for requests with expected JSON content", () => {
     type Endpoint = typeof http.post<"/resource">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const request = resolver.parameter(0).toHaveProperty("request");
@@ -34,7 +34,7 @@ describe("Given an OpenAPI schema endpoint with request content", () => {
       .returns.resolves.toEqualTypeOf<{ name: string; value: number }>();
   });
 
-  test("When a request uses a special JSON mime type, Then the content is strict-typed", async () => {
+  test("provides strict types for requests with special JSON mime type content", () => {
     type Endpoint = typeof http.post<"/special-json">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const request = resolver.parameter(0).toHaveProperty("request");
@@ -45,7 +45,7 @@ describe("Given an OpenAPI schema endpoint with request content", () => {
       .returns.resolves.toEqualTypeOf<{ name: string; value: number }>();
   });
 
-  test("When a request content is optional, Then the content is strict-typed with optional", () => {
+  test("types the content as optional for requests with optional content", () => {
     type Endpoint = typeof http.patch<"/resource">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const request = resolver.parameter(0).toHaveProperty("request");
@@ -57,7 +57,7 @@ describe("Given an OpenAPI schema endpoint with request content", () => {
       >();
   });
 
-  test("When a request accepts multiple media types, Then both body parsers are typed for their media type", () => {
+  test("provides types to each parsing method for requests that accept multiple media types", () => {
     type Endpoint = typeof http.post<"/multi-body">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const request = resolver.parameter(0).toHaveProperty("request");
@@ -70,7 +70,7 @@ describe("Given an OpenAPI schema endpoint with request content", () => {
       .returns.resolves.toEqualTypeOf<{ name: string; value: number }>();
   });
 
-  test("When the request is cloned, Then it remains strict-typed", () => {
+  test("preserves the typing of a request when the request is cloned", () => {
     type Endpoint = typeof http.post<"/multi-body">;
     const resolver = expectTypeOf<Endpoint>().parameter(1);
     const request = resolver.parameter(0).toHaveProperty("request");

--- a/test/request-body.test.ts
+++ b/test/request-body.test.ts
@@ -1,13 +1,13 @@
 import { getResponse, HttpResponse } from "msw";
 import { createOpenApiHttp } from "openapi-msw";
-import { describe, expect, test } from "vitest";
+import { expect, suite, test } from "vitest";
 import type { paths } from "./fixtures/request-body.api.ts";
 
-describe("Given an OpenAPI schema endpoint with request content", () => {
+suite("Accessing requests bodies", () => {
   const http = createOpenApiHttp<paths>({ baseUrl: "*" });
 
-  test("When a request contains content, Then the content can be used in the response", async () => {
-    const request = new Request(new URL("/resource", "http://localhost:3000"), {
+  test("exposes the request content to response resolvers", async () => {
+    const request = new Request("http://localhost:3000/resource", {
       method: "post",
       body: JSON.stringify({ name: "test-name", value: 16 }),
     });

--- a/test/response-content.test.ts
+++ b/test/response-content.test.ts
@@ -66,9 +66,7 @@ suite("Mocking responses in resolver functions", () => {
   });
 
   test("returns EMPTY responses when the response helper is used with a exact status code", async () => {
-    const request = new Request(new URL("/resource", "http://localhost:3000"), {
-      method: "get",
-    });
+    const request = new Request("http://localhost:3000/resource");
 
     const handler = http.get("/resource", ({ response }) => {
       return response(204).empty();


### PR DESCRIPTION
The compatibility pipeline has been failing for a few weeks with broken type tests. Only the tests has been effected and no actual usage with later MSW versions. They were a bit too relying and MSW's internal typing.

To finally address this, this PR has to bump the MSW requirement and overhaul the test suite to rely less on internal MSW typing. Namely the return type of response resolvers is now checked with the first level type `AsyncResponseResolverReturnType` and not the transitive `HttpResponse`, which broke with the latest MSW versions.