### PR TITLE
feat: implement support for readOnly and writeOnly properties

### DIFF
--- a/.changeset/fresh-foxes-end.md
+++ b/.changeset/fresh-foxes-end.md
@@ -1,0 +1,5 @@
+---
+"openapi-msw": minor
+---
+
+Added support for _readOnly_/_writeOnly_ annotations in OpenAPI schemas. When OpenAPI-TS is configured to generate `$Read<T>`/`$Write<T>` markers, OpenAPI-MSW will process them in request and response types. Request types will not contain properties marked with _readOnly_, and response types will not contain properties marked with _writeOnly_.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format": "prettier --write .",
     "lint": "eslint . && prettier -c .",
     "test": "vitest",
-    "generate": "openapi-typescript -c ./test/fixtures/.redocly.yml",
+    "generate": "openapi-typescript -c ./test/fixtures/.redocly.yml --read-write-markers",
     "version": "changeset version && npm i",
     "release": "changeset publish"
   },

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -1,3 +1,4 @@
+import type { StripReadOnly, StripWriteOnly } from "./read-write-markers.ts";
 import type {
   ConvertToStringified,
   MapToValues,
@@ -77,9 +78,13 @@ export type RequestMap<
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       requestBody?: any;
     }
-    ? undefined extends ApiSpec[Path][Method]["requestBody"]
-      ? Partial<NonNullable<ApiSpec[Path][Method]["requestBody"]>["content"]>
-      : ApiSpec[Path][Method]["requestBody"]["content"]
+    ? StripReadOnly<
+        undefined extends ApiSpec[Path][Method]["requestBody"]
+          ? Partial<
+              NonNullable<ApiSpec[Path][Method]["requestBody"]>["content"]
+            >
+          : ApiSpec[Path][Method]["requestBody"]["content"]
+      >
     : never
   : never;
 
@@ -104,9 +109,9 @@ export type ResponseMap<
       responses: any;
     }
     ? {
-        [Status in keyof ApiSpec[Path][Method]["responses"]]: ConvertContent<
-          ApiSpec[Path][Method]["responses"][Status]
-        >["content"];
+        [Status in keyof ApiSpec[Path][Method]["responses"]]: StripWriteOnly<
+          ConvertContent<ApiSpec[Path][Method]["responses"][Status]>["content"]
+        >;
       }
     : never
   : never;

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -78,13 +78,13 @@ export type RequestMap<
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       requestBody?: any;
     }
-    ? StripReadOnly<
-        undefined extends ApiSpec[Path][Method]["requestBody"]
-          ? Partial<
-              NonNullable<ApiSpec[Path][Method]["requestBody"]>["content"]
-            >
-          : ApiSpec[Path][Method]["requestBody"]["content"]
-      >
+    ? undefined extends ApiSpec[Path][Method]["requestBody"]
+      ? Partial<
+          NonNullable<
+            StripReadOnly<ApiSpec[Path][Method]["requestBody"]>
+          >["content"]
+        >
+      : StripReadOnly<ApiSpec[Path][Method]["requestBody"]["content"]>
     : never
   : never;
 

--- a/src/read-write-markers.ts
+++ b/src/read-write-markers.ts
@@ -8,30 +8,38 @@ interface $Write<T> {
   readonly $write: T;
 }
 
+/** Returns `never` when the property `K` is `writeOnly` in `O`. `K` otherwise. */
+type ExcludeWriteKey<O extends object, K extends keyof O> =
+  Required<O>[K] extends $Write<unknown> ? never : K;
+
+/** Returns `never` when the property `K` is `readOnly` in `O`. `K` otherwise. */
+type ExcludeReadKey<O extends object, K extends keyof O> =
+  Required<O>[K] extends $Read<unknown> ? never : K;
+
 /** Recursively strips all markers from a given type. `writeOnly` properties are removed. */
 export type StripWriteOnly<T> =
-  T extends $Read<infer I>
-    ? StripWriteOnly<I>
-    : T extends (infer I)[]
-      ? StripWriteOnly<I>[]
-      : T extends object
-        ? {
-            [K in keyof T as Required<T>[K] extends $Write<unknown>
-              ? never
-              : K]: StripWriteOnly<T[K]>;
-          }
-        : T;
+  T extends $Write<unknown>
+    ? never
+    : T extends $Read<infer I>
+      ? StripWriteOnly<I>
+      : T extends (infer I)[]
+        ? StripWriteOnly<I>[]
+        : T extends object
+          ? {
+              [K in keyof T as ExcludeWriteKey<T, K>]: StripWriteOnly<T[K]>;
+            }
+          : T;
 
 /** Recursively strips all markers from a given type. `readOnly` properties are removed. */
 export type StripReadOnly<T> =
-  T extends $Write<infer I>
-    ? StripReadOnly<I>
-    : T extends (infer I)[]
-      ? StripReadOnly<I>[]
-      : T extends object
-        ? {
-            [K in keyof T as Required<T>[K] extends $Read<unknown>
-              ? never
-              : K]: StripReadOnly<T[K]>;
-          }
-        : T;
+  T extends $Read<unknown>
+    ? never
+    : T extends $Write<infer I>
+      ? StripReadOnly<I>
+      : T extends (infer I)[]
+        ? StripReadOnly<I>[]
+        : T extends object
+          ? {
+              [K in keyof T as ExcludeReadKey<T, K>]: StripReadOnly<T[K]>;
+            }
+          : T;

--- a/src/read-write-markers.ts
+++ b/src/read-write-markers.ts
@@ -1,0 +1,37 @@
+/** Generated marker for readOnly properties. */
+interface $Read<T> {
+  readonly $read: T;
+}
+
+/** Generated marker for writeOnly properties. */
+interface $Write<T> {
+  readonly $write: T;
+}
+
+/** Recursively strips all markers from a given type. `writeOnly` properties are removed. */
+export type StripWriteOnly<T> =
+  T extends $Read<infer I>
+    ? StripWriteOnly<I>
+    : T extends (infer I)[]
+      ? StripWriteOnly<I>[]
+      : T extends object
+        ? {
+            [K in keyof T as Required<T>[K] extends $Write<unknown>
+              ? never
+              : K]: StripWriteOnly<T[K]>;
+          }
+        : T;
+
+/** Recursively strips all markers from a given type. `readOnly` properties are removed. */
+export type StripReadOnly<T> =
+  T extends $Write<infer I>
+    ? StripReadOnly<I>
+    : T extends (infer I)[]
+      ? StripReadOnly<I>[]
+      : T extends object
+        ? {
+            [K in keyof T as Required<T>[K] extends $Read<unknown>
+              ? never
+              : K]: StripReadOnly<T[K]>;
+          }
+        : T;

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -123,8 +123,6 @@ export type MSWResponseResolver<
   Method extends HttpMethod,
 > = HttpResponseResolver<
   PathParams<ApiSpec, Path, Method>,
-  // FIXME:
-  // @ts-expect-error - Read/Write Markers integration hell...
   RequestBody<ApiSpec, Path, Method>,
   ResponseBody<ApiSpec, Path, Method>
 >;

--- a/src/response-resolver.ts
+++ b/src/response-resolver.ts
@@ -123,6 +123,8 @@ export type MSWResponseResolver<
   Method extends HttpMethod,
 > = HttpResponseResolver<
   PathParams<ApiSpec, Path, Method>,
+  // FIXME:
+  // @ts-expect-error - Read/Write Markers integration hell...
   RequestBody<ApiSpec, Path, Method>,
   ResponseBody<ApiSpec, Path, Method>
 >;

--- a/test/fixtures/.redocly.yml
+++ b/test/fixtures/.redocly.yml
@@ -23,6 +23,10 @@ apis:
     root: ./query-params.api.yml
     x-openapi-ts:
       output: ./query-params.api.ts
+  read-write-markers:
+    root: ./read-write-markers.api.yml
+    x-openapi-ts:
+      output: ./read-write-markers.api.ts
   request-body:
     root: ./request-body.api.yml
     x-openapi-ts:

--- a/test/fixtures/read-write-markers.api.yml
+++ b/test/fixtures/read-write-markers.api.yml
@@ -1,0 +1,66 @@
+openapi: 3.0.2
+info:
+  title: Access Constraints API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3000
+paths:
+  /resource:
+    post:
+      summary: Create Resource
+      operationId: createResource
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Resource"
+      responses:
+        201:
+          description: Created
+    get:
+      summary: Get Resource
+      operationId: getResource
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Resource"
+components:
+  schemas:
+    Resource:
+      type: object
+      required:
+        - id
+        - name
+        - secret
+        - nested
+      properties:
+        id:
+          readOnly: true
+          type: string
+        name:
+          type: string
+        secret:
+          writeOnly: true
+          type: number
+        nested:
+          allOf:
+            - $ref: "#/components/schemas/NestedResource"
+    NestedResource:
+      type: object
+      required:
+        - id
+        - name
+        - secret
+      properties:
+        id:
+          readOnly: true
+          type: string
+        name:
+          type: string
+        secret:
+          writeOnly: true
+          type: number

--- a/test/fixtures/read-write-markers.api.yml
+++ b/test/fixtures/read-write-markers.api.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 info:
-  title: Access Constraints API
+  title: Read-Write Markers API
   version: 1.0.0
 servers:
   - url: http://localhost:3000
@@ -18,6 +18,18 @@ paths:
       responses:
         201:
           description: Created
+    patch:
+      summary: Patch Resource
+      operationId: patchResource
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Resource"
+      responses:
+        204:
+          description: No Content
     get:
       summary: Get Resource
       operationId: getResource
@@ -28,6 +40,17 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Resource"
+  /resource-list:
+    get:
+      summary: Get Resource With Lists
+      operationId: getResourceLists
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceWithLists"
 components:
   schemas:
     Resource:
@@ -64,3 +87,24 @@ components:
         secret:
           writeOnly: true
           type: number
+    ResourceWithLists:
+      type: object
+      required:
+        - ids
+        - names
+        - nested
+      properties:
+        ids:
+          readOnly: true
+          type: array
+          items:
+            type: number
+        names:
+          writeOnly: true
+          type: array
+          items:
+            type: string
+        nested:
+          type: array
+          items:
+            - $ref: "#/components/schemas/NestedResource"

--- a/test/read-write-markers.test-d.ts
+++ b/test/read-write-markers.test-d.ts
@@ -18,6 +18,21 @@ suite("Generating read-write markers", () => {
     }>();
   });
 
+  test("hides readOnly properties in optional request bodies", () => {
+    type Endpoint = typeof http.patch<"/resource">;
+    const resolver = expectTypeOf<Endpoint>().parameter(1);
+    const request = resolver.parameter(0).toHaveProperty("request");
+
+    request.toHaveProperty("json").returns.resolves.toEqualTypeOf<
+      | {
+          name: string;
+          secret: number;
+          nested: { name: string; secret: number };
+        }
+      | undefined
+    >();
+  });
+
   test("hides writeOnly properties in response helper", () => {
     http.get("/resource", ({ response }) => {
       expectTypeOf(response(200).json).parameter(0).toEqualTypeOf<{
@@ -48,5 +63,16 @@ suite("Generating read-write markers", () => {
         nested: { id: string; name: string };
       }>
     >();
+  });
+
+  test("strips markers from responses with arrays", () => {
+    http.get("/resource-list", ({ response }) => {
+      expectTypeOf(response(200).json).returns.toEqualTypeOf<
+        HttpResponse<{
+          ids: number[];
+          nested: { id: string; name: string }[];
+        }>
+      >();
+    });
   });
 });

--- a/test/read-write-markers.test-d.ts
+++ b/test/read-write-markers.test-d.ts
@@ -1,0 +1,52 @@
+import type { AsyncResponseResolverReturnType, HttpResponse } from "msw";
+import { createOpenApiHttp } from "openapi-msw";
+import { expectTypeOf, suite, test } from "vitest";
+import type { paths } from "./fixtures/read-write-markers.api.ts";
+
+suite("Generating read-write markers", () => {
+  const http = createOpenApiHttp<paths>();
+
+  test("hides readOnly properties in request bodies", () => {
+    type Endpoint = typeof http.post<"/resource">;
+    const resolver = expectTypeOf<Endpoint>().parameter(1);
+    const request = resolver.parameter(0).toHaveProperty("request");
+
+    request.toHaveProperty("json").returns.resolves.toEqualTypeOf<{
+      name: string;
+      secret: number;
+      nested: { name: string; secret: number };
+    }>();
+  });
+
+  test("hides writeOnly properties in response helper", () => {
+    http.get("/resource", ({ response }) => {
+      expectTypeOf(response(200).json).parameter(0).toEqualTypeOf<{
+        id: string;
+        name: string;
+        nested: { id: string; name: string };
+      }>();
+
+      expectTypeOf(response(200).json).returns.toEqualTypeOf<
+        HttpResponse<{
+          id: string;
+          name: string;
+          nested: { id: string; name: string };
+        }>
+      >();
+    });
+  });
+
+  test("hides writeOnly properties in resolver return type", () => {
+    type Endpoint = typeof http.get<"/resource">;
+    const resolver = expectTypeOf<Endpoint>().parameter(1);
+    const response = resolver.returns;
+
+    response.toEqualTypeOf<
+      AsyncResponseResolverReturnType<{
+        id: string;
+        name: string;
+        nested: { id: string; name: string };
+      }>
+    >();
+  });
+});


### PR DESCRIPTION
OpenAPI-TS added support for `readOnly` and `writeOnly` properties ([release notes](https://github.com/openapi-ts/openapi-typescript/releases/tag/openapi-typescript%407.13.0)). 

This PR adds support for the OpenAPI-TS feature to OpenAPI-MSW:
- `readOnly` properties are stripped from request typings.
- `writeOnly` properties are stripped from response typings.

> [!NOTE]
> Multiple bugs have been reported in OpenAPI-TS that are caused by this feature. Until the implementation stabilizes, I am waiting with merging this into OpenAPI-MSW.

### Open Issues

- [x] This change causes a type error in `response-resolver.ts`...