### PR TITLE
test: use OpenApi v3.1.2 for test fixtures

### DIFF
--- a/test/fixtures/http-methods.api.yml
+++ b/test/fixtures/http-methods.api.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.2
 info:
   title: Http Methods API
   version: 1.0.0

--- a/test/fixtures/http-utilities.api.yml
+++ b/test/fixtures/http-utilities.api.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.2
 info:
   title: Http Utilities API
   version: 1.0.0

--- a/test/fixtures/no-content.api.yml
+++ b/test/fixtures/no-content.api.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.2
 info:
   title: No Content API
   version: 1.0.0

--- a/test/fixtures/options.api.yml
+++ b/test/fixtures/options.api.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.2
 info:
   title: Options API
   version: 1.0.0

--- a/test/fixtures/path-fragments.api.yml
+++ b/test/fixtures/path-fragments.api.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.2
 info:
   title: Path Fragments API
   version: 1.0.0

--- a/test/fixtures/query-params.api.yml
+++ b/test/fixtures/query-params.api.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.2
 info:
   title: Options API
   version: 1.0.0

--- a/test/fixtures/request-body.api.yml
+++ b/test/fixtures/request-body.api.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.2
 info:
   title: Request Body API
   version: 1.0.0

--- a/test/fixtures/response-content.api.yml
+++ b/test/fixtures/response-content.api.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.2
 info:
   title: Response Content API
   version: 1.0.0


### PR DESCRIPTION
Updates the OpenApi specification version in test fixtures to v3.1.2 compared to v3.0.2.